### PR TITLE
Tighten spacing between question heading and hint

### DIFF
--- a/data/forms/textboxes.yml
+++ b/data/forms/textboxes.yml
@@ -26,7 +26,7 @@ content: >
           Textbox
         </label>
         <input type="text" name="question-1" id="question-1" class="text-box" value="" />
-        <label for="question-2" class="question-heading">
+        <label for="question-2" class="question-heading-with-hint">
           Textbox with hint
         </label>
         <p class="hint">
@@ -37,6 +37,6 @@ content: >
           Large textbox
         </label>
         <textarea class="text-box text-box-large" name="question-3" id="question-3">Large textbox</textarea>
-      </form> 
+      </form>
     </div>
   </main>

--- a/forms/textboxes.html
+++ b/forms/textboxes.html
@@ -126,7 +126,7 @@
         Textbox
       </label>
       <input type="text" name="question-1" id="question-1" class="text-box" value="" />
-      <label for="question-2" class="question-heading">
+      <label for="question-2" class="question-heading-with-hint">
         Textbox with hint
       </label>
       <p class="hint">
@@ -137,7 +137,7 @@
         Large textbox
       </label>
       <textarea class="text-box text-box-large" name="question-3" id="question-3">Large textbox</textarea>
-    </form> 
+    </form>
   </div>
 </main>
 

--- a/gh-pages-assets/stylesheets/forms/index.css
+++ b/gh-pages-assets/stylesheets/forms/index.css
@@ -70,7 +70,7 @@
 @-o-viewport {
   width: device-width; }
 
-.question-heading {
+.question-heading, .question-heading-with-hint {
   display: block;
   font-family: "nta", Arial, sans-serif;
   font-size: 24px;
@@ -82,11 +82,11 @@
   font-weight: bold;
   margin: 0 0 10px 0; }
   @media (max-width: 640px) {
-    .question-heading {
+    .question-heading, .question-heading-with-hint {
       font-size: 18px;
       line-height: 1.2; } }
   @media (min-width: 641px) {
-    .question-heading {
+    .question-heading, .question-heading-with-hint {
       padding-top: 6px;
       padding-bottom: 4px; } }
 

--- a/scss/forms/_question-headings.scss
+++ b/scss/forms/_question-headings.scss
@@ -9,6 +9,7 @@
 }
 
 .question-heading-with-hint {
+  @extend .question-heading;
   margin-bottom: 0;
 }
 
@@ -17,4 +18,3 @@
   margin: 0 0 10px 0;
   clear: left;
 }
-


### PR DESCRIPTION
There is a separate `question-heading-with-hint` class which reduces the spacing between the heading and hint to visually group them.

This commit
- Adds that class to the markup
- Extends the regular `question-heading` class so it isn't necessary to use both in the markup

Before:
![screen shot 2015-01-05 at 09 13 58](https://cloud.githubusercontent.com/assets/355079/5611274/77731dfc-94bc-11e4-8381-bd74603f633b.png)

After:
![screen shot 2015-01-05 at 09 22 55](https://cloud.githubusercontent.com/assets/355079/5611277/7c01830e-94bc-11e4-92cb-3b561dfec9a0.png)