### PR TITLE
Extend placeholder selectors, not classes

### DIFF
--- a/scss/_notification-banners.scss
+++ b/scss/_notification-banners.scss
@@ -2,7 +2,8 @@
 @import "_digital-marketplace-colours.scss";
 @import "_typography.scss";
 
-.banner {
+.banner,
+%banner {
   background: $highlight-colour;
   @include core-24;
   padding: 20px 20px 25px 20px;
@@ -10,19 +11,19 @@
 }
 
 .banner-destructive {
-  @extend .banner;
+  @extend %banner;
   border-left: 5px solid $red;
   color: $red;
 }
 
 .banner-warning {
-  @extend .banner;
+  @extend %banner;
   border-left: 5px solid $accessible-orange;
   color: $accessible-orange;
 }
 
 .banner-success {
-  @extend .banner;
+  @extend %banner;
   border-left: 5px solid $green;
   color: $green;
 }
@@ -40,4 +41,3 @@
   margin: 0;
   padding: 0;
 }
-

--- a/scss/forms/_question-headings.scss
+++ b/scss/forms/_question-headings.scss
@@ -1,7 +1,8 @@
 @import "_colours";
 @import "_typography.scss";
 
-.question-heading {
+.question-heading,
+%question-heading {
   display: block;
   @include heading-24;
   font-weight: bold;
@@ -9,7 +10,7 @@
 }
 
 .question-heading-with-hint {
-  @extend .question-heading;
+  @extend %question-heading;
   margin-bottom: 0;
 }
 


### PR DESCRIPTION
The behaviour of `@extend` in SASS can unexpectedly:
- result in properties getting applied more generally than the syntax would suggest
- result in bloated CSS

This can be mitigated by only ever extending placeholder selectors (eg `%foo` rather than `.foo`).

[More explantion in this blog post](http://csswizardry.com/2014/01/extending-silent-classes-in-sass/).

Also worth noting that SCSSLint has an [option that warns about extending classes](https://github.com/causes/scss-lint/blob/master/lib/scss_lint/linter/README.md#placeholderinextend). 