### PR TITLE
Add selection buttons

### DIFF
--- a/scss/forms/_selection-buttons.scss
+++ b/scss/forms/_selection-buttons.scss
@@ -9,7 +9,7 @@
 @import "conditionals";
 
 // By default, block labels stack vertically
-.block-label {
+.selection-button {
 
   display: block;
   float: none;
@@ -18,7 +18,7 @@
 
   background: $panel-colour;
   border: 1px solid $panel-colour;
-  padding: (18px $gutter $gutter-half $gutter*1.5);
+  padding: 10px $gutter-half 10px ($gutter * 1.5); /* padding specific to Digital Marketplace */
   margin-top: 10px;
   margin-bottom: 10px;
 
@@ -45,8 +45,7 @@
   }
 }
 
-// To stack horizontally, use .inline on parent, to sit block labels next to each other
-.inline .block-label {
+.selection-button-boolean {
   clear: none;
   margin-right: $gutter-half;
 }
@@ -54,17 +53,23 @@
 // Selected and focused states
 
 // Add selected state
-.js-enabled label.selected {
+.js-enabled label.selection-button-selected {
   background: $white;
   border-color: $black;
 }
 
 // Add focus to block labels
-.js-enabled label.focused {
+.js-enabled label.selection-button-focused {
   outline: 3px solid $yellow;
 }
 
 // Remove focus from radio/checkboxes
-.js-enabled .focused input:focus {
+.js-enabled .selection-button-focused input:focus {
   outline: none;
 }
+
+// Styles specific to Digital Marketplace
+.selection-button-with-description {
+  margin-top: 15px;
+}
+

--- a/scss/forms/_selection-buttons.scss
+++ b/scss/forms/_selection-buttons.scss
@@ -1,0 +1,70 @@
+// Copied from GOVUK Elements
+// Version: https://github.com/alphagov/govuk_elements/commit/391eab1554b05629804837ac0f87583f5b88b1a7
+//
+// Large hit area
+// Radio buttons & checkboxes
+
+@import "colours";
+@import "measurements";
+@import "conditionals";
+
+// By default, block labels stack vertically
+.block-label {
+
+  display: block;
+  float: none;
+  clear: left;
+  position: relative;
+
+  background: $panel-colour;
+  border: 1px solid $panel-colour;
+  padding: (18px $gutter $gutter-half $gutter*1.5);
+  margin-top: 10px;
+  margin-bottom: 10px;
+
+  cursor: pointer; // Encourage clicking on block labels
+
+  @include media(tablet) {
+    float: left;
+    margin-top: 5px;
+    margin-bottom: 5px;
+    // width: 25%; - Test : check that text within labels will wrap
+  }
+
+  // Absolutely position inputs within label, to allow text to wrap
+  input {
+    position: absolute;
+    top: 18px;
+    left: $gutter-half;
+    cursor: pointer;
+  }
+
+  // Change border on hover
+  &:hover {
+    border-color: $black;
+  }
+}
+
+// To stack horizontally, use .inline on parent, to sit block labels next to each other
+.inline .block-label {
+  clear: none;
+  margin-right: $gutter-half;
+}
+
+// Selected and focused states
+
+// Add selected state
+.js-enabled label.selected {
+  background: $white;
+  border-color: $black;
+}
+
+// Add focus to block labels
+.js-enabled label.focused {
+  outline: 3px solid $yellow;
+}
+
+// Remove focus from radio/checkboxes
+.js-enabled .focused input:focus {
+  outline: none;
+}


### PR DESCRIPTION
Adds the GOVUK Elements selection buttons adapted to fit the styles used on Digital Marketplace projects.

This pull request is the updated version of https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/5.

This code is added to the Github page in https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/9