### PR TITLE
Add govuk_elements version of selection buttons

### DIFF
--- a/forms/selection-buttons.html
+++ b/forms/selection-buttons.html
@@ -125,34 +125,34 @@
       <fieldset>
         <legend class="question-heading">Radio buttons</legend>
         <label class="selection-button">
-          Radio 1
+          Hour
           <input type="radio" name="radio-1" id="radio-1" value="val-1" />
         </label>
         <label class="selection-button">
-          Radio 2
+          Day
           <input type="radio" name="radio-1" id="radio-2" value="val-2" />
         </label>
         <label class="selection-button">
-          Radio 3
+          Month
           <input type="radio" name="radio-1" id="radio-3" value="val-3" />
         </label>
         <label class="selection-button">
-          Radio 4
+          Year
           <input type="radio" name="radio-1" id="radio-4" value="val-4" />
         </label>
       </fieldset>
       <fieldset>
         <legend class="question-heading">Checkboxes</legend>
         <label class="selection-button">
-          Checkbox 1
+          Accounting and finance
           <input type="checkbox" name="checkbox-1" id="checkbox-1" value="val-1" />
         </label>
         <label class="selection-button">
-          Checkbox 2
+          Business intelligence and analytics
           <input type="checkbox" name="checkbox-2" id="checkbox-2" value="val-2" />
         </label>
         <label class="selection-button">
-          Checkbox 3
+          Collaboration
           <input type="checkbox" name="checkbox-3" id="checkbox-3" value="val-3" />
         </label>
       </fieldset>
@@ -173,11 +173,13 @@
           Hint giving some information about how to answer the question.
         </p>
         <label class="selection-button selection-button-with-description">
-          Checkbox 4
+          Infrastructure as a Service (IaaS) 
           <input type="checkbox" name="checkbox-4" id="checkbox-4" value="val-4" />
         </label>
         <p class="question-description">
-          Description of the answer above.
+          Infrastructure is the hardware that makes software work. It's the networks, hosting facilities 
+          and servers that platforms and software depend on. IaaS is infrastructure you can order and run 
+          entirely over the internet, without having to pay for your own hardware.
         </p>
       </fieldset>
     </form>

--- a/gh-pages/data/forms/selection-buttons.yml
+++ b/gh-pages/data/forms/selection-buttons.yml
@@ -30,34 +30,34 @@ content: >
         <fieldset>
           <legend class="question-heading">Radio buttons</legend>
           <label class="selection-button">
-            Radio 1
+            Hour
             <input type="radio" name="radio-1" id="radio-1" value="val-1" />
           </label>
           <label class="selection-button">
-            Radio 2
+            Day
             <input type="radio" name="radio-1" id="radio-2" value="val-2" />
           </label>
           <label class="selection-button">
-            Radio 3
+            Month
             <input type="radio" name="radio-1" id="radio-3" value="val-3" />
           </label>
           <label class="selection-button">
-            Radio 4
+            Year
             <input type="radio" name="radio-1" id="radio-4" value="val-4" />
           </label>
         </fieldset>
         <fieldset>
           <legend class="question-heading">Checkboxes</legend>
           <label class="selection-button">
-            Checkbox 1
+            Accounting and finance
             <input type="checkbox" name="checkbox-1" id="checkbox-1" value="val-1" />
           </label>
           <label class="selection-button">
-            Checkbox 2
+            Business intelligence and analytics
             <input type="checkbox" name="checkbox-2" id="checkbox-2" value="val-2" />
           </label>
           <label class="selection-button">
-            Checkbox 3
+            Collaboration
             <input type="checkbox" name="checkbox-3" id="checkbox-3" value="val-3" />
           </label>
         </fieldset>
@@ -78,11 +78,13 @@ content: >
             Hint giving some information about how to answer the question.
           </p>
           <label class="selection-button selection-button-with-description">
-            Checkbox 4
+            Infrastructure as a Service (IaaS) 
             <input type="checkbox" name="checkbox-4" id="checkbox-4" value="val-4" />
           </label>
           <p class="question-description">
-            Description of the answer above.
+            Infrastructure is the hardware that makes software work. It's the networks, hosting facilities 
+            and servers that platforms and software depend on. IaaS is infrastructure you can order and run 
+            entirely over the internet, without having to pay for your own hardware.
           </p>
         </fieldset>
       </form>

--- a/gh-pages/public/stylesheets/forms/index.css
+++ b/gh-pages/public/stylesheets/forms/index.css
@@ -60,10 +60,6 @@
       font-size: 16px;
       line-height: 1.25; } }
 
-@font-face {
-  font-family: GDS-Logo;
-  src: local("HelveticaNeue"), local("Helvetica Neue"), local("Arial"), local("Helvetica"); }
-
 @-ms-viewport {
   width: device-width; }
 
@@ -76,43 +72,51 @@
   line-height: 1.31579;
   font-weight: 400;
   text-transform: none;
+  /* Specific to Digital Marketplace */
   display: block;
-  float: left;
+  float: none;
   clear: left;
   position: relative;
   background: #dee0e2;
   border: 1px solid #dee0e2;
   padding: 10px 15px 10px 45px;
-  margin-bottom: 15px;
+  /* Specific to Digital Marketplace */
+  margin-top: 10px;
+  margin-bottom: 10px;
   cursor: pointer; }
   @media (max-width: 640px) {
     .selection-button {
       font-size: 16px;
       line-height: 1.25; } }
+  @media (min-width: 641px) {
+    .selection-button {
+      float: left;
+      margin-top: 5px;
+      margin-bottom: 5px; } }
   .selection-button input {
     position: absolute;
-    top: 11px;
+    top: 12px;
     left: 15px;
     cursor: pointer; }
-
-.selection-button:hover {
-  border-color: #0b0c0c; }
-
-.selection-button-with-description {
-  margin-top: 15px; }
-
-.selection-button-selected {
-  background: #fff;
-  border-color: #0b0c0c; }
-
-.selection-button-focused {
-  outline: 3px solid #ffbf47; }
-  .selection-button-focused input:focus {
-    outline: none; }
+  .selection-button:hover {
+    border-color: #0b0c0c; }
 
 .selection-button-boolean {
   clear: none;
   margin-right: 15px; }
+
+.js-enabled label.selection-button-selected {
+  background: #fff;
+  border-color: #0b0c0c; }
+
+.js-enabled label.selection-button-focused {
+  outline: 3px solid #ffbf47; }
+
+.js-enabled .selection-button-focused input:focus {
+  outline: none; }
+
+.selection-button-with-description {
+  margin-top: 15px; }
 
 @font-face {
   font-family: GDS-Logo;

--- a/scss/forms/_selection-buttons.scss
+++ b/scss/forms/_selection-buttons.scss
@@ -1,50 +1,47 @@
-@import "_colours.scss";
-@import "_measurements.scss";
-@import "_typography.scss";
+// Copied from GOVUK Elements
+// Version: https://github.com/alphagov/govuk_elements/commit/391eab1554b05629804837ac0f87583f5b88b1a7
+//
+// Large hit area
+// Radio buttons & checkboxes
 
+@import "colours";
+@import "measurements";
+@import "conditionals";
+
+// By default, block labels stack vertically
 .selection-button {
-  @include core-19;
-  // By default, block labels stack vertically
+
   display: block;
-  float: left;
+  float: none;
   clear: left;
   position: relative;
+
   background: $panel-colour;
   border: 1px solid $panel-colour;
-  padding: 10px 15px 10px 45px;
-  margin-bottom: 15px;
-  cursor: pointer;
+  padding: 10px $gutter-half 10px ($gutter * 1.5); /* padding specific to Digital Marketplace */
+  margin-top: 10px;
+  margin-bottom: 10px;
 
+  cursor: pointer; // Encourage clicking on block labels
+
+  @include media(tablet) {
+    float: left;
+    margin-top: 5px;
+    margin-bottom: 5px;
+    // width: 25%; - Test : check that text within labels will wrap
+  }
+
+  // Absolutely position inputs within label, to allow text to wrap
   input {
     position: absolute;
-    top: 11px;
+    top: 18px;
     left: $gutter-half;
     cursor: pointer;
   }
-}
 
-// Change border on hover
-.selection-button:hover {
-  border-color: $black;
-}
-
-.selection-button-with-description {
-  margin-top: 15px;
-}
-
-// Add selected state
-.selection-button-selected {
-  background: $white;
-  border-color: $black;
-}
-
-// Add focus to block labels
-.selection-button-focused {
-  outline: 3px solid $yellow;
-
-  // Remove focus from radio/checkboxes
-  input:focus {
-    outline: none;
+  // Change border on hover
+  &:hover {
+    border-color: $black;
   }
 }
 
@@ -52,3 +49,27 @@
   clear: none;
   margin-right: $gutter-half;
 }
+
+// Selected and focused states
+
+// Add selected state
+.js-enabled label.selection-button-selected {
+  background: $white;
+  border-color: $black;
+}
+
+// Add focus to block labels
+.js-enabled label.selection-button-focused {
+  outline: 3px solid $yellow;
+}
+
+// Remove focus from radio/checkboxes
+.js-enabled .selection-button-focused input:focus {
+  outline: none;
+}
+
+// Styles specific to Digital Marketplace
+.selection-button-with-description {
+  margin-top: 15px;
+}
+

--- a/scss/forms/_selection-buttons.scss
+++ b/scss/forms/_selection-buttons.scss
@@ -11,6 +11,7 @@
 // By default, block labels stack vertically
 .selection-button {
 
+  @include core-19; /* Specific to Digital Marketplace */
   display: block;
   float: none;
   clear: left;
@@ -18,7 +19,7 @@
 
   background: $panel-colour;
   border: 1px solid $panel-colour;
-  padding: 10px $gutter-half 10px ($gutter * 1.5); /* padding specific to Digital Marketplace */
+  padding: 10px $gutter-half 10px ($gutter * 1.5); /* Specific to Digital Marketplace */
   margin-top: 10px;
   margin-bottom: 10px;
 
@@ -34,7 +35,7 @@
   // Absolutely position inputs within label, to allow text to wrap
   input {
     position: absolute;
-    top: 18px;
+    top: 12px;
     left: $gutter-half;
     cursor: pointer;
   }


### PR DESCRIPTION
Adds the GOVUK Elements selection buttons adapted to fit the styles used on Digital Marketplace projects.

![selection-buttons-screenshot](https://cloud.githubusercontent.com/assets/87140/5665288/46bee9bc-974f-11e4-85e7-a3249937db1b.png)

This pull request is the updated version of https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/5.

This code is added to the Github page in https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/9