### PR TITLE
Add support for older versions of Internet Explorer

### DIFF
--- a/gh-pages/assets/scss/forms/index-ie6.scss
+++ b/gh-pages/assets/scss/forms/index-ie6.scss
@@ -1,0 +1,7 @@
+// BASE STYLESHEET FOR IE 6 COMPILER
+
+$is-ie: true;
+$ie-version: 6;
+$mobile-ie6: false;
+
+@import "index.scss";

--- a/gh-pages/assets/scss/forms/index-ie7.scss
+++ b/gh-pages/assets/scss/forms/index-ie7.scss
@@ -1,0 +1,7 @@
+// BASE STYLESHEET FOR IE 7 COMPILER
+
+$is-ie: true;
+$ie-version: 7;
+$mobile-ie6: false;
+
+@import "index.scss";

--- a/gh-pages/assets/scss/forms/index-ie8.scss
+++ b/gh-pages/assets/scss/forms/index-ie8.scss
@@ -1,0 +1,7 @@
+// BASE STYLESHEET FOR IE 8 COMPILER
+
+$is-ie: true;
+$ie-version: 8;
+$mobile-ie6: false;
+
+@import "index.scss";

--- a/gh-pages/data/forms/summary.yml
+++ b/gh-pages/data/forms/summary.yml
@@ -2,7 +2,18 @@ pageTitle: Summary - Forms - Test toolkit
 assetPath: ../govuk_template/assets/
 head: >
   <link rel="stylesheet" media="all" type="text/css" href="../gh-pages/public/stylesheets/index.css" />
-  <link rel="stylesheet" media="all" type="text/css" href="../gh-pages/public/stylesheets/forms/index.css" />
+  <!--[if gt IE 8]><!-->
+    <link rel="stylesheet" media="all" type="text/css" href="../gh-pages/public/stylesheets/forms/index.css" />
+  <!--<![endif]-->
+  <!--[if IE 6]>
+    <link rel="stylesheet" media="all" type="text/css" href="../gh-pages/public/stylesheets/forms/index-ie6.css" />
+  <![endif]-->
+  <!--[if IE 7]>
+    <link rel="stylesheet" media="all" type="text/css" href="../gh-pages/public/stylesheets/forms/index-ie7.css" />
+  <![endif]-->
+  <!--[if IE 8]>
+    <link rel="stylesheet" media="all" type="text/css" href="../gh-pages/public/stylesheets/forms/index-ie8.css" />
+  <![endif]-->
 content: >
   <div id="global-breadcrumb" class="header-context">
     <nav>

--- a/scss/README.md
+++ b/scss/README.md
@@ -1,6 +1,6 @@
 # SCSS
 
-Digitial Marketplace uses the
+Digital Marketplace uses the
 [SCSS](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#syntax) of Sass.
 
 ## Support for older versions of Internet Explorer
@@ -17,18 +17,19 @@ Support for older versions of Internet Explorer is made possible by the use of t
 ### Required set up
 
 This works by using the [sass-ie](http://jakearchibald.github.io/sass-ie/) method which generates a
-separate stylesheet for each version you need to target.
+separate stylesheet for each version of Internet Explorer that you need to target.
 
-An example of this can be seen with the
+An example of this can be seen on the
 [forms/summary.html](http://alphagov.github.io/digitalmarketplace-frontend-toolkit/forms/summary.html)
-page. Looking at the [gh-pages/data/forms/summary.yml](../gh-pages/data/forms/summary.yml) file you
-can see the `forms/index.css` stylesheet has variants for IE6, 7 & 8. The conditional comments they are
-wrapped in ensure each browser only gets its variant. They also ensure none of those are requested
-by all others browsers.
+page. In [gh-pages/data/forms/summary.yml](../gh-pages/data/forms/summary.yml) you
+can see that `forms/index.css` has variants for IE6, 7 and 8. The links to the
+stylesheets are wrapped in conditional comments to ensure that:
+- each version of Internet Explorer only gets its variant
+- other browsers don't request the Internet-Explorer-specific stylesheets
 
-Looking at the SCSS file for the IE6 variant you can see it just includes `forms/index.scss` while
-setting a few variables the mixins from `_conditionals.scss` use to determine whether or not to
-insert their given block.
+The SCSS file for IE6 just includes `forms/index.scss` while setting a
+few variables. The mixins from `_conditionals.scss` use these variables
+to determine whether or not to insert the block of browser-specific CSS.
 
 ```
 $is-ie: true;

--- a/scss/README.md
+++ b/scss/README.md
@@ -1,0 +1,39 @@
+# SCSS
+
+Digitial Marketplace uses the
+[SCSS](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#syntax) of Sass.
+
+## Support for older versions of Internet Explorer
+
+Support for older versions of Internet Explorer is made possible by the use of the mixins in
+[_conditionals.scss](../govuk_frontend_toolkit/stylesheets/_conditionals.scss).
+
+```
+@include ie(6) {
+  /* Block of IE6-specific SCSS */
+}
+```
+
+### Required set up
+
+This works by using the [sass-ie](http://jakearchibald.github.io/sass-ie/) method which generates a
+separate stylesheet for each version you need to target.
+
+An example of this can be seen with the
+[forms/summary.html](http://alphagov.github.io/digitalmarketplace-frontend-toolkit/forms/summary.html)
+page. Looking at the [gh-pages/data/forms/summary.yml](../gh-pages/data/forms/summary.yml) file you
+can see the `forms/index.css` stylesheet has variants for IE6, 7 & 8. The conditional comments they are
+wrapped in ensure each browser only gets its variant. They also ensure none of those are requested
+by all others browsers.
+
+Looking at the SCSS file for the IE6 variant you can see it just includes `forms/index.scss` while
+setting a few variables the mixins from `_conditionals.scss` use to determine whether or not to
+insert their given block.
+
+```
+$is-ie: true;
+$ie-version: 6;
+$mobile-ie6: false;
+
+@import "index.scss";
+```


### PR DESCRIPTION
This adds the support for older version of IE built into www.gov.uk projects to the pages with an explanation of how to implement it.