### PR TITLE
Extend question headings

### DIFF
--- a/scss/forms/_questions.scss
+++ b/scss/forms/_questions.scss
@@ -1,0 +1,29 @@
+@import "_colours";
+@import "_typography.scss";
+
+.question {
+  margin: 15px 0 0 0;
+  clear: both;
+}
+
+.first-question {
+  margin-top: 0;
+}
+
+.question-heading {
+  display: block;
+  @include heading-24;
+  font-weight: bold;
+  margin: 0 0 10px 0;
+}
+
+.question-heading-with-hint {
+  @extend .question-heading;
+  margin-bottom: 0;
+}
+
+.question-description {
+  @include copy-19;
+  margin: 0 0 10px 0;
+  clear: left;
+}

--- a/scss/forms/_questions.scss
+++ b/scss/forms/_questions.scss
@@ -6,7 +6,7 @@
   clear: both;
 }
 
-.first-question {
+.question-first {
   margin-top: 0;
 }
 

--- a/scss/forms/_selection-buttons.scss
+++ b/scss/forms/_selection-buttons.scss
@@ -1,50 +1,48 @@
-@import "_colours.scss";
-@import "_measurements.scss";
-@import "_typography.scss";
+// Copied from GOVUK Elements
+// Version: https://github.com/alphagov/govuk_elements/commit/391eab1554b05629804837ac0f87583f5b88b1a7
+//
+// Large hit area
+// Radio buttons & checkboxes
 
+@import "colours";
+@import "measurements";
+@import "conditionals";
+
+// By default, block labels stack vertically
 .selection-button {
-  @include core-19;
-  // By default, block labels stack vertically
+
+  @include core-19; /* Specific to Digital Marketplace */
   display: block;
-  float: left;
+  float: none;
   clear: left;
   position: relative;
+
   background: $panel-colour;
   border: 1px solid $panel-colour;
-  padding: 10px 15px 10px 45px;
-  margin-bottom: 15px;
-  cursor: pointer;
+  padding: 10px $gutter-half 10px ($gutter * 1.5); /* Specific to Digital Marketplace */
+  margin-top: 10px;
+  margin-bottom: 10px;
 
+  cursor: pointer; // Encourage clicking on block labels
+
+  @include media(tablet) {
+    float: left;
+    margin-top: 5px;
+    margin-bottom: 5px;
+    // width: 25%; - Test : check that text within labels will wrap
+  }
+
+  // Absolutely position inputs within label, to allow text to wrap
   input {
     position: absolute;
-    top: 11px;
+    top: 12px;
     left: $gutter-half;
     cursor: pointer;
   }
-}
 
-// Change border on hover
-.selection-button:hover {
-  border-color: $black;
-}
-
-.selection-button-with-description {
-  margin-top: 15px;
-}
-
-// Add selected state
-.selection-button-selected {
-  background: $white;
-  border-color: $black;
-}
-
-// Add focus to block labels
-.selection-button-focused {
-  outline: 3px solid $yellow;
-
-  // Remove focus from radio/checkboxes
-  input:focus {
-    outline: none;
+  // Change border on hover
+  &:hover {
+    border-color: $black;
   }
 }
 
@@ -52,3 +50,27 @@
   clear: none;
   margin-right: $gutter-half;
 }
+
+// Selected and focused states
+
+// Add selected state
+.js-enabled label.selection-button-selected {
+  background: $white;
+  border-color: $black;
+}
+
+// Add focus to block labels
+.js-enabled label.selection-button-focused {
+  outline: 3px solid $yellow;
+}
+
+// Remove focus from radio/checkboxes
+.js-enabled .selection-button-focused input:focus {
+  outline: none;
+}
+
+// Styles specific to Digital Marketplace
+.selection-button-with-description {
+  margin-top: 15px;
+}
+

--- a/scss/forms/_summary.scss
+++ b/scss/forms/_summary.scss
@@ -19,6 +19,10 @@
   @include box-sizing(border-box);
 }
 
+.first-summary-item-heading {
+  padding-top: 0;
+}
+
 .summary-item-heading-number {
   position: absolute;
   width: 40px;


### PR DESCRIPTION
Extends the existing `question-headings.scss` file to include code for the question and answer formatting developed as part of the Supplier Submission Portal. (now called `questions.scss`.)

See https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/15 for an example.

Also includes some code changes missed from previous pull requests.