### PR TITLE
Extend question headings page

### DIFF
--- a/forms/index.html
+++ b/forms/index.html
@@ -138,7 +138,7 @@
         <a href="summary.html">Summary</a>
       </li>
       <li>
-        <a href="multi-selects.html">Multi-selects</a>
+        <a href="question-and-answer-format.html">Question and answer format</a>
       </li>
     </ul>
   </div>

--- a/forms/list-entry.html
+++ b/forms/list-entry.html
@@ -122,7 +122,7 @@
       <h1>List entry textbox</h1>
     </header>
     <form action="" method="get">
-      <fieldset class="question" id="p5q1">
+      <fieldset class="question first-question" id="p5q1">
         <legend class="question-heading  question-heading-with-hint ">
           List entry textbox
         </legend>

--- a/forms/question-and-answer-format.html
+++ b/forms/question-and-answer-format.html
@@ -5,7 +5,7 @@
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
 
-    <title>Selection buttons - Test toolkit</title>
+    <title>Question and answer format - Test toolkit</title>
 
     <script type="text/javascript">
       (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
@@ -119,68 +119,45 @@
 </div> <main role="main" id="content" class="wrapper">
   <div id="wrapper">
     <header class="page-heading">
-      <h1>Selection buttons</h1>
+      <h1>Question and answer format</h1>
     </header>
     <form action="" method="get">
-      <fieldset class="question first-question">
-        <legend class="question-heading">Radio buttons</legend>
-        <label class="selection-button">
-          Hour
-          <input type="radio" name="radio-1" id="radio-1" value="val-1" />
+      <div class="question first-question">
+        <label for="question-1" class="question-heading question-heading-with-hint">
+          Question a with single answer
         </label>
-        <label class="selection-button">
-          Day
-          <input type="radio" name="radio-1" id="radio-2" value="val-2" />
-        </label>
-        <label class="selection-button">
-          Month
-          <input type="radio" name="radio-1" id="radio-3" value="val-3" />
-        </label>
-        <label class="selection-button">
-          Year
-          <input type="radio" name="radio-1" id="radio-4" value="val-4" />
-        </label>
-      </fieldset>
-      <fieldset class="question">
-        <legend class="question-heading">Checkboxes</legend>
-        <label class="selection-button">
-          Accounting and finance
-          <input type="checkbox" name="checkbox-1" id="checkbox-1" value="val-1" />
-        </label>
-        <label class="selection-button">
-          Business intelligence and analytics
-          <input type="checkbox" name="checkbox-2" id="checkbox-2" value="val-2" />
-        </label>
-        <label class="selection-button">
-          Collaboration
-          <input type="checkbox" name="checkbox-3" id="checkbox-3" value="val-3" />
-        </label>
-      </fieldset>
-      <fieldset class="question">
-        <legend class="question-heading">Boolean</legend>
-        <label class="selection-button selection-button-boolean">
-          Yes
-          <input type="radio" name="boolean-1" id="boolean-1" value="val-1" />
-        </label>
-        <label class="selection-button selection-button-boolean">
-          No
-          <input type="radio" name="boolean-1" id="boolean-2" value="val-2" />
-        </label>
-      </fieldset>
-      <fieldset class="question">
-        <legend class="question-heading question-heading-with-hint">Checkbox with hint and description</legend>
         <p class="hint">
-          Hint giving some information about how to answer the question.
+          the question and answer are wrapped in a div with the question the answer field's label
         </p>
-        <label class="selection-button selection-button-with-description">
-          Infrastructure as a Service (IaaS) 
-          <input type="checkbox" name="checkbox-4" id="checkbox-4" value="val-4" />
+        <input type="text" name="question-1" id="question-1" class="text-box" value="" />
+      </div>
+      <fieldset class="question" id="question-2">
+        <legend class="question-heading question-heading-with-hint ">
+          Question with multiple answers
+        </legend>
+        <p class="hint">
+          the question and answer are wrapped in a fieldset with the question its legend
+        </p>
+        <label class="selection-button">
+          <input type="checkbox" name="question-2" id="question-2-answer-1" value="answer-1" />
+          Answer 1
         </label>
-        <p class="question-description">
-          Infrastructure is the hardware that makes software work. It's the networks, hosting facilities 
-          and servers that platforms and software depend on. IaaS is infrastructure you can order and run 
-          entirely over the internet, without having to pay for your own hardware.
-        </p>
+        <label class="selection-button">
+          <input type="checkbox" name="question-2" id="question-2-answer-2" value="answer-2" />
+          Answer 2
+        </label>
+        <label class="selection-button">
+          <input type="checkbox" name="question-2" id="question-2-answer-3" value="answer-3" />
+          Answer 3
+        </label>
+        <label class="selection-button">
+          <input type="checkbox" name="question-2" id="question-2-answer-4" value="answer-4" />
+          Answer 4
+        </label>
+        <label class="selection-button">
+          <input type="checkbox" name="question-2" id="question-2-answer-5" value="answer-5" />
+          Answer 5
+        </label>
       </fieldset>
     </form>
   </div>
@@ -215,7 +192,6 @@
 
     <script src="../govuk_template/assets/javascripts/govuk-template.js?0.12.0" type="text/javascript"></script>
 
-    <script type="text/javascript" src="../gh-pages/public/javascripts/vendor/jquery-1.11.0.js"></script> <script type="text/javascript" src="../govuk_frontend_toolkit/javascripts/vendor/polyfills/bind.js"></script> <script type="text/javascript" src="../govuk_frontend_toolkit/javascripts/govuk/selection-buttons.js"></script> <script type="text/javascript" src="../gh-pages/public/javascripts/onready.js"></script>
-
+    
   </body>
 </html>

--- a/forms/summary.html
+++ b/forms/summary.html
@@ -129,7 +129,7 @@
     <header class="page-heading">
       <h1>Summary</h1>
     </header>
-    <h2 class="summary-item-heading">
+    <h2 class="summary-item-heading first-summary-item-heading">
         Summary item with no entries
     </h2>
     <p class="hint summary-item-no-content">

--- a/forms/textboxes.html
+++ b/forms/textboxes.html
@@ -122,21 +122,27 @@
       <h1>Textboxes</h1>
     </header>
     <form action="" method="get">
-      <label for="question-1" class="question-heading">
-        Textbox
-      </label>
-      <input type="text" name="question-1" id="question-1" class="text-box" value="" />
-      <label for="question-2" class="question-heading-with-hint">
-        Textbox with hint
-      </label>
-      <p class="hint">
-        Hint comprising further information about the question.
-      </p>
-      <input type="text" name="question-2" id="question-2" class="text-box" value="" />
-      <label for="question-1" class="question-heading">
-        Large textbox
-      </label>
-      <textarea class="text-box text-box-large" name="question-3" id="question-3">Large textbox</textarea>
+      <div class="question first-question">
+        <label for="question-1" class="question-heading">
+          Textbox
+        </label>
+        <input type="text" name="question-1" id="question-1" class="text-box" value="" />
+      </div>
+      <div class="question">
+        <label for="question-2" class="question-heading-with-hint">
+          Textbox with hint
+        </label>
+        <p class="hint">
+          Hint comprising further information about the question.
+        </p>
+        <input type="text" name="question-2" id="question-2" class="text-box" value="" />
+      </div>
+      <div class="question">
+        <label for="question-1" class="question-heading">
+          Large textbox
+        </label>
+        <textarea class="text-box text-box-large" name="question-3" id="question-3">Large textbox</textarea>
+      </div>
     </form>
   </div>
 </main>

--- a/forms/word-count.html
+++ b/forms/word-count.html
@@ -122,7 +122,7 @@
       <h1>Textbox with word count</h1>
     </header>
     <form action="" method="get">
-      <div class="word-count">
+      <div class="word-count question first-question">
         <label for="p4q2-text-box" class="question-heading question-heading-with-hint">
           Textbox with word count
         </label>

--- a/gh-pages/assets/scss/forms/index.scss
+++ b/gh-pages/assets/scss/forms/index.scss
@@ -1,6 +1,6 @@
 @import "forms/_textboxes.scss";
 @import "forms/_selection-buttons.scss";
-@import "forms/_question-headings.scss";
+@import "forms/_questions.scss";
 @import "forms/_hint.scss";
 @import "forms/_word-counter.scss";
 @import "forms/_list-entry.scss";

--- a/gh-pages/data/forms/index.yml
+++ b/gh-pages/data/forms/index.yml
@@ -37,7 +37,7 @@ content: >
           <a href="summary.html">Summary</a>
         </li>
         <li>
-          <a href="multi-selects.html">Multi-selects</a>
+          <a href="question-and-answer-format.html">Question and answer format</a>
         </li>
       </ul>
     </div>

--- a/gh-pages/data/forms/list-entry.yml
+++ b/gh-pages/data/forms/list-entry.yml
@@ -28,7 +28,7 @@ content: >
         <h1>List entry textbox</h1>
       </header>
       <form action="" method="get">
-        <fieldset class="question" id="p5q1">
+        <fieldset class="question first-question" id="p5q1">
           <legend class="question-heading  question-heading-with-hint ">
             List entry textbox
           </legend>

--- a/gh-pages/data/forms/question-and-answer-format.yml
+++ b/gh-pages/data/forms/question-and-answer-format.yml
@@ -1,0 +1,64 @@
+pageTitle: Question and answer format - Test toolkit
+assetPath: ../govuk_template/assets/
+head: >
+  <link rel="stylesheet" media="all" type="text/css" href="../gh-pages/public/stylesheets/index.css" />
+  <link rel="stylesheet" media="all" type="text/css" href="../gh-pages/public/stylesheets/forms/index.css" />
+content: >
+  <div id="global-breadcrumb" class="header-context">
+    <nav>
+      <ol class="group" role="breadcrumbs">
+        <li>
+          <a href="../">Home</a>
+        </li>
+        <li>
+          <a href="./">Forms</a>
+        </li>
+      </ol>
+    </nav>
+  </div>
+  <main role="main" id="content" class="wrapper">
+    <div id="wrapper">
+      <header class="page-heading">
+        <h1>Question and answer format</h1>
+      </header>
+      <form action="" method="get">
+        <div class="question first-question">
+          <label for="question-1" class="question-heading question-heading-with-hint">
+            Question a with single answer
+          </label>
+          <p class="hint">
+            the question and answer are wrapped in a div with the question the answer field's label
+          </p>
+          <input type="text" name="question-1" id="question-1" class="text-box" value="" />
+        </div>
+        <fieldset class="question" id="question-2">
+          <legend class="question-heading question-heading-with-hint ">
+            Question with multiple answers
+          </legend>
+          <p class="hint">
+            the question and answer are wrapped in a fieldset with the question its legend
+          </p>
+          <label class="selection-button">
+            <input type="checkbox" name="question-2" id="question-2-answer-1" value="answer-1" />
+            Answer 1
+          </label>
+          <label class="selection-button">
+            <input type="checkbox" name="question-2" id="question-2-answer-2" value="answer-2" />
+            Answer 2
+          </label>
+          <label class="selection-button">
+            <input type="checkbox" name="question-2" id="question-2-answer-3" value="answer-3" />
+            Answer 3
+          </label>
+          <label class="selection-button">
+            <input type="checkbox" name="question-2" id="question-2-answer-4" value="answer-4" />
+            Answer 4
+          </label>
+          <label class="selection-button">
+            <input type="checkbox" name="question-2" id="question-2-answer-5" value="answer-5" />
+            Answer 5
+          </label>
+        </fieldset>
+      </form>
+    </div>
+  </main>

--- a/gh-pages/data/forms/selection-buttons.yml
+++ b/gh-pages/data/forms/selection-buttons.yml
@@ -27,7 +27,7 @@ content: >
         <h1>Selection buttons</h1>
       </header>
       <form action="" method="get">
-        <fieldset>
+        <fieldset class="question first-question">
           <legend class="question-heading">Radio buttons</legend>
           <label class="selection-button">
             Hour
@@ -46,7 +46,7 @@ content: >
             <input type="radio" name="radio-1" id="radio-4" value="val-4" />
           </label>
         </fieldset>
-        <fieldset>
+        <fieldset class="question">
           <legend class="question-heading">Checkboxes</legend>
           <label class="selection-button">
             Accounting and finance
@@ -61,7 +61,7 @@ content: >
             <input type="checkbox" name="checkbox-3" id="checkbox-3" value="val-3" />
           </label>
         </fieldset>
-        <fieldset>
+        <fieldset class="question">
           <legend class="question-heading">Boolean</legend>
           <label class="selection-button selection-button-boolean">
             Yes
@@ -72,7 +72,7 @@ content: >
             <input type="radio" name="boolean-1" id="boolean-2" value="val-2" />
           </label>
         </fieldset>
-        <fieldset>
+        <fieldset class="question">
           <legend class="question-heading question-heading-with-hint">Checkbox with hint and description</legend>
           <p class="hint">
             Hint giving some information about how to answer the question.

--- a/gh-pages/data/forms/summary.yml
+++ b/gh-pages/data/forms/summary.yml
@@ -32,7 +32,7 @@ content: >
       <header class="page-heading">
         <h1>Summary</h1>
       </header>
-      <h2 class="summary-item-heading">
+      <h2 class="summary-item-heading first-summary-item-heading">
           Summary item with no entries
       </h2>
       <p class="hint summary-item-no-content">

--- a/gh-pages/data/forms/textboxes.yml
+++ b/gh-pages/data/forms/textboxes.yml
@@ -22,21 +22,27 @@ content: >
         <h1>Textboxes</h1>
       </header>
       <form action="" method="get">
-        <label for="question-1" class="question-heading">
-          Textbox
-        </label>
-        <input type="text" name="question-1" id="question-1" class="text-box" value="" />
-        <label for="question-2" class="question-heading-with-hint">
-          Textbox with hint
-        </label>
-        <p class="hint">
-          Hint comprising further information about the question.
-        </p>
-        <input type="text" name="question-2" id="question-2" class="text-box" value="" />
-        <label for="question-1" class="question-heading">
-          Large textbox
-        </label>
-        <textarea class="text-box text-box-large" name="question-3" id="question-3">Large textbox</textarea>
+        <div class="question first-question">
+          <label for="question-1" class="question-heading">
+            Textbox
+          </label>
+          <input type="text" name="question-1" id="question-1" class="text-box" value="" />
+        </div>
+        <div class="question">
+          <label for="question-2" class="question-heading-with-hint">
+            Textbox with hint
+          </label>
+          <p class="hint">
+            Hint comprising further information about the question.
+          </p>
+          <input type="text" name="question-2" id="question-2" class="text-box" value="" />
+        </div>
+        <div class="question">
+          <label for="question-1" class="question-heading">
+            Large textbox
+          </label>
+          <textarea class="text-box text-box-large" name="question-3" id="question-3">Large textbox</textarea>
+        </div>
       </form>
     </div>
   </main>

--- a/gh-pages/data/forms/word-count.yml
+++ b/gh-pages/data/forms/word-count.yml
@@ -28,7 +28,7 @@ content: >
         <h1>Textbox with word count</h1>
       </header>
       <form action="" method="get">
-        <div class="word-count">
+        <div class="word-count question first-question">
           <label for="p4q2-text-box" class="question-heading question-heading-with-hint">
             Textbox with word count
           </label>

--- a/gh-pages/public/stylesheets/forms/index-ie6.css
+++ b/gh-pages/public/stylesheets/forms/index-ie6.css
@@ -58,10 +58,6 @@
       font-size: 16px;
       line-height: 1.25; } }
 
-@font-face {
-  font-family: GDS-Logo;
-  src: local("HelveticaNeue"), local("Helvetica Neue"), local("Arial"), local("Helvetica"); }
-
 @-ms-viewport {
   width: device-width; }
 
@@ -74,43 +70,49 @@
   line-height: 1.31579;
   font-weight: 400;
   text-transform: none;
+  /* Specific to Digital Marketplace */
   display: block;
-  float: left;
+  float: none;
   clear: left;
   position: relative;
   background: #dee0e2;
   border: 1px solid #dee0e2;
   padding: 10px 15px 10px 45px;
-  margin-bottom: 15px;
-  cursor: pointer; }
+  /* Specific to Digital Marketplace */
+  margin-top: 10px;
+  margin-bottom: 10px;
+  cursor: pointer;
+  float: left;
+  margin-top: 5px;
+  margin-bottom: 5px; }
   @media (max-width: 640px) {
     .selection-button {
       font-size: 16px;
       line-height: 1.25; } }
   .selection-button input {
     position: absolute;
-    top: 11px;
+    top: 12px;
     left: 15px;
     cursor: pointer; }
-
-.selection-button:hover {
-  border-color: #0b0c0c; }
-
-.selection-button-with-description {
-  margin-top: 15px; }
-
-.selection-button-selected {
-  background: #fff;
-  border-color: #0b0c0c; }
-
-.selection-button-focused {
-  outline: 3px solid #ffbf47; }
-  .selection-button-focused input:focus {
-    outline: none; }
+  .selection-button:hover {
+    border-color: #0b0c0c; }
 
 .selection-button-boolean {
   clear: none;
   margin-right: 15px; }
+
+.js-enabled label.selection-button-selected {
+  background: #fff;
+  border-color: #0b0c0c; }
+
+.js-enabled label.selection-button-focused {
+  outline: 3px solid #ffbf47; }
+
+.js-enabled .selection-button-focused input:focus {
+  outline: none; }
+
+.selection-button-with-description {
+  margin-top: 15px; }
 
 @font-face {
   font-family: GDS-Logo;
@@ -121,6 +123,13 @@
 
 @-o-viewport {
   width: device-width; }
+
+.question {
+  margin: 15px 0 0 0;
+  clear: both; }
+
+.first-question {
+  margin-top: 0; }
 
 .question-heading, .question-heading-with-hint {
   display: block;
@@ -234,13 +243,6 @@
 
 @-o-viewport {
   width: device-width; }
-
-.checkbox-filter .head {
-  zoom: 1; }
-  .checkbox-filter .head:after {
-    content: "";
-    display: block;
-    clear: both; }
 
 .input-list .list-entry {
   vertical-align: middle; }
@@ -426,114 +428,3 @@
   color: #cd4c0b; }
   .summary-item-row-incomplete .summary-item-content-field a {
     color: #cd4c0b; }
-
-@-ms-viewport {
-  width: device-width; }
-
-@-o-viewport {
-  width: device-width; }
-
-.checkbox-filter .head {
-  zoom: 1; }
-  .checkbox-filter .head:after {
-    content: "";
-    display: block;
-    clear: both; }
-
-.filter {
-  margin-bottom: 30px;
-  background-color: #dee0e2;
-  padding: 0 5px; }
-  .filter:focus {
-    outline: 3px solid #ffbf47; }
-  .filter .legend {
-    font-family: "nta", Arial, sans-serif;
-    font-size: 19px;
-    line-height: 1.31579;
-    font-weight: 400;
-    text-transform: none;
-    display: -moz-inline-stack;
-    display: inline-block;
-    zoom: 1;
-    display: inline;
-    margin-right: 40px;
-    font-weight: bold;
-    padding-top: 10px; }
-    @media (max-width: 640px) {
-      .filter .legend {
-        font-size: 16px;
-        line-height: 1.25; } }
-
-.radio-filter, .text-filter {
-  padding: 0 10px; }
-  .radio-filter label, .text-filter label {
-    margin-right: 10px;
-    display: -moz-inline-stack;
-    display: inline-block;
-    zoom: 1;
-    display: inline; }
-
-.radio-filter input {
-  width: 14px; }
-
-.checkbox-filter {
-  padding-bottom: 5px;
-  /* Only apply these styles to chrome/firefox/safari and ie8 upwards
-     this is because checkbox filters are always open on ie6/7 so no
-     need to have closed styles or toggles. */
-  /* Redefine scrollbars so they are always visible in scrolling checkbox lists */ }
-  .checkbox-filter:hover {
-    background-color: #bfc1c3; }
-  .checkbox-filter ::-webkit-scrollbar {
-    -webkit-appearance: none;
-    width: 7px; }
-  .checkbox-filter ::-webkit-scrollbar-thumb {
-    border-radius: 4px;
-    background-color: rgba(0, 0, 0, 0.5);
-    -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, 0.5); }
-  .checkbox-filter .head {
-    padding: 0 5px;
-    position: relative; }
-    .checkbox-filter .head .controls {
-      position: absolute;
-      right: 5px;
-      top: 10px; }
-      .checkbox-filter .head .controls .clear-selected {
-        display: -moz-inline-stack;
-        display: inline-block;
-        zoom: 1;
-        display: inline;
-        margin-right: 5px; }
-        .checkbox-filter .head .controls .clear-selected.js-hidden {
-          left: -9999em;
-          position: relative;
-          height: 0px;
-          overflow: hidden; }
-  .checkbox-filter .checkbox-container {
-    position: relative;
-    margin-top: 5px;
-    background-color: #fff;
-    height: 200px;
-    overflow-y: scroll;
-    overflow-x: hidden;
-    /* IE6 doesn't support psuedo selectors so scoping to checkbox-container instead of using a psuedo selector */ }
-    .checkbox-filter .checkbox-container ul {
-      margin: 0;
-      padding: 0;
-      list-style: none; }
-      .checkbox-filter .checkbox-container ul ul {
-        padding-left: 20px; }
-    .checkbox-filter .checkbox-container label {
-      display: -moz-inline-stack;
-      display: inline-block;
-      zoom: 1;
-      display: inline;
-      padding: 7px 0 7px 30px;
-      width: 90%;
-      border-bottom: 1px solid #bfc1c3; }
-      .checkbox-filter .checkbox-container label:hover {
-        background-color: #f8f8f8; }
-    .checkbox-filter .checkbox-container input {
-      margin-left: -23px;
-      vertical-align: top;
-      position: absolute; }

--- a/gh-pages/public/stylesheets/forms/index-ie6.css
+++ b/gh-pages/public/stylesheets/forms/index-ie6.css
@@ -342,6 +342,9 @@
       font-size: 18px;
       line-height: 1.2; } }
 
+.first-summary-item-heading {
+  padding-top: 0; }
+
 .summary-item-heading-number {
   position: absolute;
   width: 40px;

--- a/gh-pages/public/stylesheets/forms/index-ie7.css
+++ b/gh-pages/public/stylesheets/forms/index-ie7.css
@@ -58,10 +58,6 @@
       font-size: 16px;
       line-height: 1.25; } }
 
-@font-face {
-  font-family: GDS-Logo;
-  src: local("HelveticaNeue"), local("Helvetica Neue"), local("Arial"), local("Helvetica"); }
-
 @-ms-viewport {
   width: device-width; }
 
@@ -74,21 +70,17 @@
   line-height: 1.31579;
   font-weight: 400;
   text-transform: none;
+  /* Specific to Digital Marketplace */
   display: block;
-  float: left;
+  float: none;
   clear: left;
   position: relative;
   background: #dee0e2;
   border: 1px solid #dee0e2;
   padding: 10px 15px 10px 45px;
+<<<<<<< HEAD
   margin-bottom: 15px;
   cursor: pointer; }
-  @media (max-width: 640px) {
-    .selection-button {
-      font-size: 16px;
-      line-height: 1.25; } }
-  .selection-button input {
-    position: absolute;
     top: 11px;
     left: 15px;
     cursor: pointer; }
@@ -111,6 +103,29 @@
 .selection-button-boolean {
   clear: none;
   margin-right: 15px; }
+=======
+    top: 12px;
+    left: 15px;
+    cursor: pointer; }
+  .selection-button:hover {
+    border-color: #0b0c0c; }
+
+.selection-button-boolean {
+  clear: none;
+  margin-right: 15px; }
+
+.js-enabled label.selection-button-selected {
+  background: #fff;
+  border-color: #0b0c0c; }
+
+.js-enabled label.selection-button-focused {
+  outline: 3px solid #ffbf47; }
+
+.js-enabled .selection-button-focused input:focus {
+  outline: none; }
+
+.selection-button-with-description {
+  margin-top: 15px; }
 
 @font-face {
   font-family: GDS-Logo;
@@ -121,6 +136,13 @@
 
 @-o-viewport {
   width: device-width; }
+
+.question {
+  margin: 15px 0 0 0;
+  clear: both; }
+
+.first-question {
+  margin-top: 0; }
 
 .question-heading, .question-heading-with-hint {
   display: block;
@@ -234,13 +256,6 @@
 
 @-o-viewport {
   width: device-width; }
-
-.checkbox-filter .head {
-  zoom: 1; }
-  .checkbox-filter .head:after {
-    content: "";
-    display: block;
-    clear: both; }
 
 .input-list .list-entry {
   vertical-align: middle; }
@@ -425,114 +440,3 @@
   color: #cd4c0b; }
   .summary-item-row-incomplete .summary-item-content-field a {
     color: #cd4c0b; }
-
-@-ms-viewport {
-  width: device-width; }
-
-@-o-viewport {
-  width: device-width; }
-
-.checkbox-filter .head {
-  zoom: 1; }
-  .checkbox-filter .head:after {
-    content: "";
-    display: block;
-    clear: both; }
-
-.filter {
-  margin-bottom: 30px;
-  background-color: #dee0e2;
-  padding: 0 5px; }
-  .filter:focus {
-    outline: 3px solid #ffbf47; }
-  .filter .legend {
-    font-family: "nta", Arial, sans-serif;
-    font-size: 19px;
-    line-height: 1.31579;
-    font-weight: 400;
-    text-transform: none;
-    display: -moz-inline-stack;
-    display: inline-block;
-    zoom: 1;
-    display: inline;
-    margin-right: 40px;
-    font-weight: bold;
-    padding-top: 10px; }
-    @media (max-width: 640px) {
-      .filter .legend {
-        font-size: 16px;
-        line-height: 1.25; } }
-
-.radio-filter, .text-filter {
-  padding: 0 10px; }
-  .radio-filter label, .text-filter label {
-    margin-right: 10px;
-    display: -moz-inline-stack;
-    display: inline-block;
-    zoom: 1;
-    display: inline; }
-
-.radio-filter input {
-  width: 14px; }
-
-.checkbox-filter {
-  padding-bottom: 5px;
-  /* Only apply these styles to chrome/firefox/safari and ie8 upwards
-     this is because checkbox filters are always open on ie6/7 so no
-     need to have closed styles or toggles. */
-  /* Redefine scrollbars so they are always visible in scrolling checkbox lists */ }
-  .checkbox-filter:hover {
-    background-color: #bfc1c3; }
-  .checkbox-filter ::-webkit-scrollbar {
-    -webkit-appearance: none;
-    width: 7px; }
-  .checkbox-filter ::-webkit-scrollbar-thumb {
-    border-radius: 4px;
-    background-color: rgba(0, 0, 0, 0.5);
-    -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, 0.5); }
-  .checkbox-filter .head {
-    padding: 0 5px;
-    position: relative; }
-    .checkbox-filter .head .controls {
-      position: absolute;
-      right: 5px;
-      top: 10px; }
-      .checkbox-filter .head .controls .clear-selected {
-        display: -moz-inline-stack;
-        display: inline-block;
-        zoom: 1;
-        display: inline;
-        margin-right: 5px; }
-        .checkbox-filter .head .controls .clear-selected.js-hidden {
-          left: -9999em;
-          position: relative;
-          height: 0px;
-          overflow: hidden; }
-  .checkbox-filter .checkbox-container {
-    position: relative;
-    margin-top: 5px;
-    background-color: #fff;
-    height: 200px;
-    overflow-y: scroll;
-    overflow-x: hidden;
-    /* IE6 doesn't support psuedo selectors so scoping to checkbox-container instead of using a psuedo selector */ }
-    .checkbox-filter .checkbox-container ul {
-      margin: 0;
-      padding: 0;
-      list-style: none; }
-      .checkbox-filter .checkbox-container ul ul {
-        padding-left: 20px; }
-    .checkbox-filter .checkbox-container label {
-      display: -moz-inline-stack;
-      display: inline-block;
-      zoom: 1;
-      display: inline;
-      padding: 7px 0 7px 30px;
-      width: 90%;
-      border-bottom: 1px solid #bfc1c3; }
-      .checkbox-filter .checkbox-container label:hover {
-        background-color: #f8f8f8; }
-    .checkbox-filter .checkbox-container input {
-      margin-left: -23px;
-      vertical-align: top;
-      position: absolute; }

--- a/gh-pages/public/stylesheets/forms/index-ie7.css
+++ b/gh-pages/public/stylesheets/forms/index-ie7.css
@@ -355,6 +355,9 @@
       font-size: 18px;
       line-height: 1.2; } }
 
+.first-summary-item-heading {
+  padding-top: 0; }
+
 .summary-item-heading-number {
   position: absolute;
   width: 40px;

--- a/gh-pages/public/stylesheets/forms/index-ie8.css
+++ b/gh-pages/public/stylesheets/forms/index-ie8.css
@@ -338,6 +338,9 @@
       font-size: 18px;
       line-height: 1.2; } }
 
+.first-summary-item-heading {
+  padding-top: 0; }
+
 .summary-item-heading-number {
   position: absolute;
   width: 40px;

--- a/gh-pages/public/stylesheets/forms/index-ie8.css
+++ b/gh-pages/public/stylesheets/forms/index-ie8.css
@@ -58,10 +58,6 @@
       font-size: 16px;
       line-height: 1.25; } }
 
-@font-face {
-  font-family: GDS-Logo;
-  src: local("HelveticaNeue"), local("Helvetica Neue"), local("Arial"), local("Helvetica"); }
-
 @-ms-viewport {
   width: device-width; }
 
@@ -74,43 +70,49 @@
   line-height: 1.31579;
   font-weight: 400;
   text-transform: none;
+  /* Specific to Digital Marketplace */
   display: block;
-  float: left;
+  float: none;
   clear: left;
   position: relative;
   background: #dee0e2;
   border: 1px solid #dee0e2;
   padding: 10px 15px 10px 45px;
-  margin-bottom: 15px;
-  cursor: pointer; }
+  /* Specific to Digital Marketplace */
+  margin-top: 10px;
+  margin-bottom: 10px;
+  cursor: pointer;
+  float: left;
+  margin-top: 5px;
+  margin-bottom: 5px; }
   @media (max-width: 640px) {
     .selection-button {
       font-size: 16px;
       line-height: 1.25; } }
   .selection-button input {
     position: absolute;
-    top: 11px;
+    top: 12px;
     left: 15px;
     cursor: pointer; }
-
-.selection-button:hover {
-  border-color: #0b0c0c; }
-
-.selection-button-with-description {
-  margin-top: 15px; }
-
-.selection-button-selected {
-  background: #fff;
-  border-color: #0b0c0c; }
-
-.selection-button-focused {
-  outline: 3px solid #ffbf47; }
-  .selection-button-focused input:focus {
-    outline: none; }
+  .selection-button:hover {
+    border-color: #0b0c0c; }
 
 .selection-button-boolean {
   clear: none;
   margin-right: 15px; }
+
+.js-enabled label.selection-button-selected {
+  background: #fff;
+  border-color: #0b0c0c; }
+
+.js-enabled label.selection-button-focused {
+  outline: 3px solid #ffbf47; }
+
+.js-enabled .selection-button-focused input:focus {
+  outline: none; }
+
+.selection-button-with-description {
+  margin-top: 15px; }
 
 @font-face {
   font-family: GDS-Logo;
@@ -121,6 +123,13 @@
 
 @-o-viewport {
   width: device-width; }
+
+.question {
+  margin: 15px 0 0 0;
+  clear: both; }
+
+.first-question {
+  margin-top: 0; }
 
 .question-heading, .question-heading-with-hint {
   display: block;
@@ -234,11 +243,6 @@
 
 @-o-viewport {
   width: device-width; }
-
-.checkbox-filter .head:after {
-  content: "";
-  display: block;
-  clear: both; }
 
 .input-list .list-entry {
   vertical-align: middle; }
@@ -419,125 +423,3 @@
   color: #cd4c0b; }
   .summary-item-row-incomplete .summary-item-content-field a {
     color: #cd4c0b; }
-
-@-ms-viewport {
-  width: device-width; }
-
-@-o-viewport {
-  width: device-width; }
-
-.checkbox-filter .head:after {
-  content: "";
-  display: block;
-  clear: both; }
-
-.filter {
-  margin-bottom: 30px;
-  background-color: #dee0e2;
-  padding: 0 5px; }
-  .filter:focus {
-    outline: 3px solid #ffbf47; }
-  .filter .legend {
-    font-family: "nta", Arial, sans-serif;
-    font-size: 19px;
-    line-height: 1.31579;
-    font-weight: 400;
-    text-transform: none;
-    display: -moz-inline-stack;
-    display: inline-block;
-    margin-right: 40px;
-    font-weight: bold;
-    padding-top: 10px; }
-    @media (max-width: 640px) {
-      .filter .legend {
-        font-size: 16px;
-        line-height: 1.25; } }
-
-.radio-filter, .text-filter {
-  padding: 0 10px; }
-  .radio-filter label, .text-filter label {
-    margin-right: 10px;
-    display: -moz-inline-stack;
-    display: inline-block; }
-
-.radio-filter input {
-  width: 14px; }
-
-.checkbox-filter {
-  padding-bottom: 5px;
-  /* Only apply these styles to chrome/firefox/safari and ie8 upwards
-     this is because checkbox filters are always open on ie6/7 so no
-     need to have closed styles or toggles. */
-  /* Redefine scrollbars so they are always visible in scrolling checkbox lists */ }
-  .checkbox-filter:hover {
-    background-color: #bfc1c3; }
-  .js-enabled .checkbox-filter .head {
-    cursor: pointer; }
-  .js-enabled .checkbox-filter .toggle {
-    height: 15px;
-    width: 23px;
-    display: -moz-inline-stack;
-    display: inline-block;
-    background-image: url("./toggle-sprite.png");
-    background-repeat: no-repeat;
-    background-position: 0 3px; }
-    @media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min--moz-device-pixel-ratio: 2), only screen and (-o-min-device-pixel-ratio: 20/10), only screen and (min-device-pixel-ratio: 2), only screen and (min-resolution: 192dpi), only screen and (min-resolution: 2dppx) {
-      .js-enabled .checkbox-filter .toggle {
-        background-image: url("./toggle-sprite-retina.png");
-        background-size: 32px 50px; } }
-  .js-enabled .checkbox-filter.closed .checkbox-container {
-    position: absolute;
-    left: -9999px;
-    padding: 0;
-    margin: 0; }
-  .js-enabled .checkbox-filter.closed .toggle {
-    background-position: 0 -33px; }
-  .checkbox-filter ::-webkit-scrollbar {
-    -webkit-appearance: none;
-    width: 7px; }
-  .checkbox-filter ::-webkit-scrollbar-thumb {
-    border-radius: 4px;
-    background-color: rgba(0, 0, 0, 0.5);
-    -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, 0.5); }
-  .checkbox-filter .head {
-    padding: 0 5px;
-    position: relative; }
-    .checkbox-filter .head .controls {
-      position: absolute;
-      right: 5px;
-      top: 10px; }
-      .checkbox-filter .head .controls .clear-selected {
-        display: -moz-inline-stack;
-        display: inline-block;
-        margin-right: 5px; }
-        .checkbox-filter .head .controls .clear-selected.js-hidden {
-          left: -9999em;
-          position: relative;
-          height: 0px;
-          overflow: hidden; }
-  .checkbox-filter .checkbox-container {
-    position: relative;
-    margin-top: 5px;
-    background-color: #fff;
-    height: 200px;
-    overflow-y: scroll;
-    overflow-x: hidden;
-    /* IE6 doesn't support psuedo selectors so scoping to checkbox-container instead of using a psuedo selector */ }
-    .checkbox-filter .checkbox-container ul {
-      margin: 0;
-      padding: 0;
-      list-style: none; }
-      .checkbox-filter .checkbox-container ul ul {
-        padding-left: 20px; }
-    .checkbox-filter .checkbox-container label {
-      display: -moz-inline-stack;
-      display: inline-block;
-      padding: 7px 0 7px 30px;
-      width: 90%;
-      border-bottom: 1px solid #bfc1c3; }
-      .checkbox-filter .checkbox-container label:hover {
-        background-color: #f8f8f8; }
-    .checkbox-filter .checkbox-container input {
-      margin-left: -23px;
-      vertical-align: top;
-      position: absolute; }

--- a/gh-pages/public/stylesheets/forms/index.css
+++ b/gh-pages/public/stylesheets/forms/index.css
@@ -128,6 +128,13 @@
 @-o-viewport {
   width: device-width; }
 
+.question {
+  margin: 15px 0 0 0;
+  clear: both; }
+
+.first-question {
+  margin-top: 0; }
+
 .question-heading, .question-heading-with-hint {
   display: block;
   font-family: "nta", Arial, sans-serif;

--- a/gh-pages/public/stylesheets/forms/index.css
+++ b/gh-pages/public/stylesheets/forms/index.css
@@ -358,6 +358,9 @@
       font-size: 18px;
       line-height: 1.2; } }
 
+.first-summary-item-heading {
+  padding-top: 0; }
+
 .summary-item-heading-number {
   position: absolute;
   width: 40px;

--- a/scss/forms/_questions.scss
+++ b/scss/forms/_questions.scss
@@ -1,6 +1,15 @@
 @import "_colours";
 @import "_typography.scss";
 
+.question {
+  margin: 15px 0 0 0;
+  clear: both;
+}
+
+.first-question {
+  margin-top: 0;
+}
+
 .question-heading {
   display: block;
   @include heading-24;

--- a/scss/forms/_questions.scss
+++ b/scss/forms/_questions.scss
@@ -6,7 +6,7 @@
   clear: both;
 }
 
-.first-question {
+.question-first {
   margin-top: 0;
 }
 

--- a/scss/forms/_summary.scss
+++ b/scss/forms/_summary.scss
@@ -19,6 +19,10 @@
   @include box-sizing(border-box);
 }
 
+.first-summary-item-heading {
+  padding-top: 0;
+}
+
 .summary-item-heading-number {
   position: absolute;
   width: 40px;


### PR DESCRIPTION
Adds an example page for the changes to the `question-headings.scss` file in https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/14.

![question-and-answer-format-screenshot](https://cloud.githubusercontent.com/assets/87140/5705590/5943ad40-9a72-11e4-82cb-54ca1c6a38d3.png)
