### PR TITLE
Set the asset path in the main SCSS file

### DIFF
--- a/forms/index.html
+++ b/forms/index.html
@@ -140,6 +140,9 @@
       <li>
         <a href="question-and-answer-format.html">Question and answer format</a>
       </li>
+      <li>
+        <a href="multi-selects.html">Multi-selects</a>
+      </li>
     </ul>
   </div>
 </main>

--- a/gh-pages/assets/scss/forms/index.scss
+++ b/gh-pages/assets/scss/forms/index.scss
@@ -1,3 +1,5 @@
+$path : 'http://alphagov.github.io/digitalmarketplace-frontend-toolkit/images/';
+
 @import "forms/_textboxes.scss";
 @import "forms/_selection-buttons.scss";
 @import "forms/_questions.scss";

--- a/gh-pages/assets/scss/index.scss
+++ b/gh-pages/assets/scss/index.scss
@@ -1,5 +1,7 @@
 @import "_grid_layout.scss";
  
+$path : 'http://alphagov.github.io/digitalmarketplace-frontend-toolkit/';
+
 #wrapper {
   @extend %site-width-container;
 }

--- a/gh-pages/assets/scss/index.scss
+++ b/gh-pages/assets/scss/index.scss
@@ -1,6 +1,6 @@
 @import "_grid_layout.scss";
  
-$path : 'http://alphagov.github.io/digitalmarketplace-frontend-toolkit/';
+$path : 'http://alphagov.github.io/digitalmarketplace-frontend-toolkit/images/';
 
 #wrapper {
   @extend %site-width-container;

--- a/gh-pages/data/forms/index.yml
+++ b/gh-pages/data/forms/index.yml
@@ -39,6 +39,9 @@ content: >
         <li>
           <a href="question-and-answer-format.html">Question and answer format</a>
         </li>
+        <li>
+          <a href="multi-selects.html">Multi-selects</a>
+        </li>
       </ul>
     </div>
   </main>

--- a/gh-pages/public/stylesheets/forms/index-ie8.css
+++ b/gh-pages/public/stylesheets/forms/index-ie8.css
@@ -496,12 +496,12 @@ table.summary-item-body {
     width: 23px;
     display: -moz-inline-stack;
     display: inline-block;
-    background-image: url("./toggle-sprite.png");
+    background-image: url('http://alphagov.github.io/digitalmarketplace-frontend-toolkit/images/toggle-sprite.png');
     background-repeat: no-repeat;
     background-position: 0 3px; }
     @media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min--moz-device-pixel-ratio: 2), only screen and (-o-min-device-pixel-ratio: 20/10), only screen and (min-device-pixel-ratio: 2), only screen and (min-resolution: 192dpi), only screen and (min-resolution: 2dppx) {
       .js-enabled .checkbox-filter .toggle {
-        background-image: url("./toggle-sprite-retina.png");
+        background-image: url('http://alphagov.github.io/digitalmarketplace-frontend-toolkit/images/toggle-sprite-retina.png');
         background-size: 32px 50px; } }
   .js-enabled .checkbox-filter.closed .checkbox-container {
     position: absolute;

--- a/gh-pages/public/stylesheets/forms/index.css
+++ b/gh-pages/public/stylesheets/forms/index.css
@@ -513,12 +513,12 @@ table.summary-item-body {
     width: 23px;
     display: -moz-inline-stack;
     display: inline-block;
-    background-image: url("./toggle-sprite.png");
+    background-image: url('http://alphagov.github.io/digitalmarketplace-frontend-toolkit/images/toggle-sprite.png');
     background-repeat: no-repeat;
     background-position: 0 3px; }
     @media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min--moz-device-pixel-ratio: 2), only screen and (-o-min-device-pixel-ratio: 20/10), only screen and (min-device-pixel-ratio: 2), only screen and (min-resolution: 192dpi), only screen and (min-resolution: 2dppx) {
       .js-enabled .checkbox-filter .toggle {
-        background-image: url("./toggle-sprite-retina.png");
+        background-image: url('http://alphagov.github.io/digitalmarketplace-frontend-toolkit/images/toggle-sprite-retina.png');
         background-size: 32px 50px; } }
   .js-enabled .checkbox-filter.closed .checkbox-container {
     position: absolute;

--- a/gh-pages/public/stylesheets/index.css
+++ b/gh-pages/public/stylesheets/index.css
@@ -147,6 +147,12 @@
 @-o-viewport {
   width: device-width; }
 
+/*
+  The file-url helper requires the setting of a $path variable to the path of your app's static
+  assets endpoint. For example:
+
+  $path : '/assets/';
+*/
 #global-breadcrumb {
   background-color: #fff;
   max-width: 1020px;

--- a/scss/_breadcrumb.scss
+++ b/scss/_breadcrumb.scss
@@ -4,7 +4,12 @@
 @import "_typography.scss";
 @import "_url-helpers.scss";
 
-$path : 'http://alphagov.github.io/digitalmarketplace-frontend-toolkit/images/';
+/*
+  The file-url helper requires the setting of a $path variable to the path of your app's static
+  assets endpoint. For example:
+
+  $path : '/assets/';
+*/
 
 #global-breadcrumb {
   background-color: $white;
@@ -23,7 +28,7 @@ $path : 'http://alphagov.github.io/digitalmarketplace-frontend-toolkit/images/';
 
       li {
         @include core-16;
-        background: file-url('breadcrumb-separator.png') 100% 50% no-repeat;
+        background: file-url('images/breadcrumb-separator.png') 100% 50% no-repeat;
         float: left;
         list-style: none;
 

--- a/scss/_breadcrumb.scss
+++ b/scss/_breadcrumb.scss
@@ -28,7 +28,7 @@
 
       li {
         @include core-16;
-        background: file-url('images/breadcrumb-separator.png') 100% 50% no-repeat;
+        background: file-url('breadcrumb-separator.png') 100% 50% no-repeat;
         float: left;
         list-style: none;
 

--- a/scss/_breadcrumb.scss
+++ b/scss/_breadcrumb.scss
@@ -8,7 +8,7 @@
   The file-url helper requires the setting of a $path variable to the path of your app's static
   assets endpoint. For example:
 
-  $path : '/assets/';
+  $path : '/assets/images/';
 */
 
 #global-breadcrumb {

--- a/scss/forms/_multi-select.scss
+++ b/scss/forms/_multi-select.scss
@@ -56,12 +56,12 @@
         height: 15px;
         width: 23px;
         @include inline-block;
-        background-image: image-url('toggle-sprite.png');
+        background-image: file-url('toggle-sprite.png');
         background-repeat:no-repeat;
         background-position:0 3px;
 
         @include device-pixel-ratio() {
-          background-image:image-url('toggle-sprite-retina.png');
+          background-image:file-url('toggle-sprite-retina.png');
           background-size: 32px 50px;
         }
       }


### PR DESCRIPTION
Sets the asset path in the github pages code, as explained in https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/20

This also includes some fixes for the use of paths in multi-select SCSS.