### PR TITLE
Fix display of headings in summary tables

### DIFF
--- a/scss/forms/_summary.scss
+++ b/scss/forms/_summary.scss
@@ -94,6 +94,15 @@ table.summary-item-body {
   padding-right: 25px;
 }
 
+.summary-item-field-headings {
+
+  tr {
+    position: absolute;
+    left: -9999em;
+  }
+  
+}
+
 .summary-item-field-content {
   @extend %summary-item-field;
   width: 50%;


### PR DESCRIPTION
These headings are only meant to be for screen readers. They are not meant to be shown visually, but at the moment they are:

![screen shot 2015-02-04 at 14 58 55](https://cloud.githubusercontent.com/assets/355079/6042647/6f9db20c-ac7e-11e4-8f5b-c080344da198.png)

This commit hides them.

*P.S. When I make the pull request on the Marketplace I'll improve the language from key/value!*
