### PR TITLE
Columns in summary tables fixed to 50% width

### DIFF
--- a/scss/forms/_summary.scss
+++ b/scss/forms/_summary.scss
@@ -83,7 +83,6 @@ table.summary-item-body {
 }
 
 %summary-item-field {
-  white-space: nowrap;
   vertical-align: middle;
   text-align: left;
 }


### PR DESCRIPTION
Need to stop this from happening:
![image](https://cloud.githubusercontent.com/assets/355079/6078795/e03f6b5a-adf4-11e4-8567-52b92a70414c.png)
