### PR TITLE
Use class naming conventions on summary page

### DIFF
--- a/forms/summary.html
+++ b/forms/summary.html
@@ -138,7 +138,7 @@
     <h2 class="summary-item-heading">
         Summary item
     </h2>
-    <table class="summary-item">
+    <table class="summary-item-body">
       <thead class="summary-item-field-headings">
         <tr>
           <th scope="col">
@@ -149,12 +149,12 @@
           </th>
         </tr>
       </thead>
-      <tbody class="summary-item-body">
+      <tbody class="summary-item">
         <tr class="summary-item-row">
-          <td class="summary-item-name-field">
+          <td class="summary-item-field-name">
             <span>Summary item name</span>
           </td>
-          <td class="summary-item-content-field">
+          <td class="summary-item-field-content">
             Summary item content
           </td>
           <td class="summary-item-action-field">
@@ -169,7 +169,7 @@
     <p class="summary-item-top-level-action">
       <a href="" class="summary-change-link">Edit <span class="visuallyhidden"> Summary item with action</span></a>
     </p>
-    <table class="summary-item">
+    <table class="summary-item-body">
       <thead class="summary-item-field-headings">
         <tr>
           <th scope="col">
@@ -180,12 +180,12 @@
           </th>
         </tr>
       </thead>
-      <tbody class="summary-item-body">
+      <tbody>
         <tr class="summary-item-row">
-          <td class="summary-item-name-field">
+          <td class="summary-item-field-name">
             <span>Summary item name</span>
           </td>
-          <td class="summary-item-content-field">
+          <td class="summary-item-field-content">
             Summary item content
           </td>
           <td class="summary-item-action-field">
@@ -198,7 +198,7 @@
         <span class="summary-item-heading-number">1.</span>
         Summary item with number
     </h2>
-    <table class="summary-item">
+    <table class="summary-item-body">
       <thead class="summary-item-field-headings">
         <tr>
           <th scope="col">
@@ -209,12 +209,12 @@
           </th>
         </tr>
       </thead>
-      <tbody class="summary-item-body">
+      <tbody>
         <tr class="summary-item-row">
-          <td class="summary-item-name-field">
+          <td class="summary-item-field-name">
             <span>Summary item name</span>
           </td>
-          <td class="summary-item-content-field">
+          <td class="summary-item-field-content">
             Summary item content
           </td>
           <td class="summary-item-action-field">
@@ -226,7 +226,7 @@
     <h2 class="summary-item-heading">
         Summary item with name field as link
     </h2>
-    <table class="summary-item">
+    <table class="summary-item-body">
       <thead class="summary-item-field-headings">
         <tr>
           <th scope="col">
@@ -237,12 +237,12 @@
           </th>
         </tr>
       </thead>
-      <tbody class="summary-item-body">
+      <tbody>
         <tr class="summary-item-row">
-          <td class="summary-item-name-field">
+          <td class="summary-item-field-name">
             <a href="">Summary item name</a>
           </td>
-          <td class="summary-item-content-field">
+          <td class="summary-item-field-content">
             Summary item content
           </td>
           <td class="summary-item-action-field">
@@ -254,7 +254,7 @@
     <h2 class="summary-item-heading">
         Summary item with content field as list
     </h2>
-    <table class="summary-item">
+    <table class="summary-item-body">
       <thead class="summary-item-field-headings">
         <tr>
           <th scope="col">
@@ -265,12 +265,12 @@
           </th>
         </tr>
       </thead>
-      <tbody class="summary-item-body">
+      <tbody class="summary-item">
         <tr class="summary-item-row">
-          <td class="summary-item-name-field">
+          <td class="summary-item-field-name">
             <span>Summary item name</span>
           </td>
-          <td class="summary-item-content-field">
+          <td class="summary-item-field-content">
             <ul>
               <li>Summary item content 1</li>
               <li>Summary item content 2</li>
@@ -285,7 +285,7 @@
     <h2 class="summary-item-heading">
         Summary item with incomplete entry
     </h2>
-    <table class="summary-item">
+    <table class="summary-item-body">
       <thead class="summary-item-field-headings">
         <tr>
           <th scope="col">
@@ -296,16 +296,16 @@
           </th>
         </tr>
       </thead>
-      <tbody class="summary-item-body">
-        <tr class="summary-item-row summary-item-row-incomplete">
-          <td class="summary-item-name-field">
+      <tbody class="summary-item">
+        <tr class="summary-item-row-incomplete">
+          <td class="summary-item-field-name">
             <span>Summary item name</span>
           </td>
-          <td class="summary-item-content-field">
-            <a href="">Summary item content</a>
+          <td class="summary-item-field-content">
+            <a href="#">Summary item content</a>
           </td>
           <td class="summary-item-action-field">
-            <a href="">Change<span class="visuallyhidden"> Summary item</span></a>
+            <a href="#">Change<span class="visuallyhidden"> Summary item</span></a>
           </td>
         </tr>
       </tbody>

--- a/gh-pages/data/forms/summary.yml
+++ b/gh-pages/data/forms/summary.yml
@@ -41,7 +41,7 @@ content: >
       <h2 class="summary-item-heading">
           Summary item
       </h2>
-      <table class="summary-item">
+      <table class="summary-item-body">
         <thead class="summary-item-field-headings">
           <tr>
             <th scope="col">
@@ -52,12 +52,12 @@ content: >
             </th>
           </tr>
         </thead>
-        <tbody class="summary-item-body">
+        <tbody class="summary-item">
           <tr class="summary-item-row">
-            <td class="summary-item-name-field">
+            <td class="summary-item-field-name">
               <span>Summary item name</span>
             </td>
-            <td class="summary-item-content-field">
+            <td class="summary-item-field-content">
               Summary item content
             </td>
             <td class="summary-item-action-field">
@@ -72,7 +72,7 @@ content: >
       <p class="summary-item-top-level-action">
         <a href="" class="summary-change-link">Edit <span class="visuallyhidden"> Summary item with action</span></a>
       </p>
-      <table class="summary-item">
+      <table class="summary-item-body">
         <thead class="summary-item-field-headings">
           <tr>
             <th scope="col">
@@ -83,12 +83,12 @@ content: >
             </th>
           </tr>
         </thead>
-        <tbody class="summary-item-body">
+        <tbody>
           <tr class="summary-item-row">
-            <td class="summary-item-name-field">
+            <td class="summary-item-field-name">
               <span>Summary item name</span>
             </td>
-            <td class="summary-item-content-field">
+            <td class="summary-item-field-content">
               Summary item content
             </td>
             <td class="summary-item-action-field">
@@ -101,7 +101,7 @@ content: >
           <span class="summary-item-heading-number">1.</span>
           Summary item with number
       </h2>
-      <table class="summary-item">
+      <table class="summary-item-body">
         <thead class="summary-item-field-headings">
           <tr>
             <th scope="col">
@@ -112,12 +112,12 @@ content: >
             </th>
           </tr>
         </thead>
-        <tbody class="summary-item-body">
+        <tbody>
           <tr class="summary-item-row">
-            <td class="summary-item-name-field">
+            <td class="summary-item-field-name">
               <span>Summary item name</span>
             </td>
-            <td class="summary-item-content-field">
+            <td class="summary-item-field-content">
               Summary item content
             </td>
             <td class="summary-item-action-field">
@@ -129,7 +129,7 @@ content: >
       <h2 class="summary-item-heading">
           Summary item with name field as link
       </h2>
-      <table class="summary-item">
+      <table class="summary-item-body">
         <thead class="summary-item-field-headings">
           <tr>
             <th scope="col">
@@ -140,12 +140,12 @@ content: >
             </th>
           </tr>
         </thead>
-        <tbody class="summary-item-body">
+        <tbody>
           <tr class="summary-item-row">
-            <td class="summary-item-name-field">
+            <td class="summary-item-field-name">
               <a href="">Summary item name</a>
             </td>
-            <td class="summary-item-content-field">
+            <td class="summary-item-field-content">
               Summary item content
             </td>
             <td class="summary-item-action-field">
@@ -157,7 +157,7 @@ content: >
       <h2 class="summary-item-heading">
           Summary item with content field as list
       </h2>
-      <table class="summary-item">
+      <table class="summary-item-body">
         <thead class="summary-item-field-headings">
           <tr>
             <th scope="col">
@@ -168,12 +168,12 @@ content: >
             </th>
           </tr>
         </thead>
-        <tbody class="summary-item-body">
+        <tbody class="summary-item">
           <tr class="summary-item-row">
-            <td class="summary-item-name-field">
+            <td class="summary-item-field-name">
               <span>Summary item name</span>
             </td>
-            <td class="summary-item-content-field">
+            <td class="summary-item-field-content">
               <ul>
                 <li>Summary item content 1</li>
                 <li>Summary item content 2</li>
@@ -188,7 +188,7 @@ content: >
       <h2 class="summary-item-heading">
           Summary item with incomplete entry
       </h2>
-      <table class="summary-item">
+      <table class="summary-item-body">
         <thead class="summary-item-field-headings">
           <tr>
             <th scope="col">
@@ -199,20 +199,19 @@ content: >
             </th>
           </tr>
         </thead>
-        <tbody class="summary-item-body">
-          <tr class="summary-item-row summary-item-row-incomplete">
-            <td class="summary-item-name-field">
+        <tbody class="summary-item">
+          <tr class="summary-item-row-incomplete">
+            <td class="summary-item-field-name">
               <span>Summary item name</span>
             </td>
-            <td class="summary-item-content-field">
-              <a href="">Summary item content</a>
+            <td class="summary-item-field-content">
+              <a href="#">Summary item content</a>
             </td>
             <td class="summary-item-action-field">
-              <a href="">Change<span class="visuallyhidden"> Summary item</span></a>
+              <a href="#">Change<span class="visuallyhidden"> Summary item</span></a>
             </td>
           </tr>
         </tbody>
       </table>
     </div>
   </main>
-

--- a/gh-pages/public/stylesheets/forms/index-ie6.css
+++ b/gh-pages/public/stylesheets/forms/index-ie6.css
@@ -418,13 +418,16 @@ table.summary-item-body {
     vertical-align: top; }
 
 .summary-item-field-name, .summary-item-field-content, .summary-item-field-action {
-  white-space: nowrap;
   vertical-align: middle;
   text-align: left; }
 
 .summary-item-field-name {
   width: 50%;
   padding-right: 25px; }
+
+.summary-item-field-headings tr {
+  position: absolute;
+  left: -9999em; }
 
 .summary-item-field-content {
   width: 50%;

--- a/gh-pages/public/stylesheets/forms/index-ie7.css
+++ b/gh-pages/public/stylesheets/forms/index-ie7.css
@@ -417,13 +417,16 @@ table.summary-item-body {
     vertical-align: top; }
 
 .summary-item-field-name, .summary-item-field-content, .summary-item-field-action {
-  white-space: nowrap;
   vertical-align: middle;
   text-align: left; }
 
 .summary-item-field-name {
   width: 50%;
   padding-right: 25px; }
+
+.summary-item-field-headings tr {
+  position: absolute;
+  left: -9999em; }
 
 .summary-item-field-content {
   width: 50%;

--- a/gh-pages/public/stylesheets/forms/index-ie8.css
+++ b/gh-pages/public/stylesheets/forms/index-ie8.css
@@ -411,13 +411,16 @@ table.summary-item-body {
     vertical-align: top; }
 
 .summary-item-field-name, .summary-item-field-content, .summary-item-field-action {
-  white-space: nowrap;
   vertical-align: middle;
   text-align: left; }
 
 .summary-item-field-name {
   width: 50%;
   padding-right: 25px; }
+
+.summary-item-field-headings tr {
+  position: absolute;
+  left: -9999em; }
 
 .summary-item-field-content {
   width: 50%;

--- a/gh-pages/public/stylesheets/forms/index.css
+++ b/gh-pages/public/stylesheets/forms/index.css
@@ -428,13 +428,16 @@ table.summary-item-body {
     vertical-align: top; }
 
 .summary-item-field-name, .summary-item-field-content, .summary-item-field-action {
-  white-space: nowrap;
   vertical-align: middle;
   text-align: left; }
 
 .summary-item-field-name {
   width: 50%;
   padding-right: 25px; }
+
+.summary-item-field-headings tr {
+  position: absolute;
+  left: -9999em; }
 
 .summary-item-field-content {
   width: 50%;

--- a/gh-pages/public/stylesheets/index.css
+++ b/gh-pages/public/stylesheets/index.css
@@ -151,7 +151,7 @@
   The file-url helper requires the setting of a $path variable to the path of your app's static
   assets endpoint. For example:
 
-  $path : '/assets/';
+  $path : '/assets/images/';
 */
 #global-breadcrumb {
   background-color: #fff;

--- a/scss/forms/_summary.scss
+++ b/scss/forms/_summary.scss
@@ -83,7 +83,6 @@ table.summary-item-body {
 }
 
 %summary-item-field {
-  white-space: nowrap;
   vertical-align: middle;
   text-align: left;
 }


### PR DESCRIPTION
The naming of classes used in the markup did not quite fit with the [naming convention](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/tree/master/scss#naming).

This meant that the summary page in the toolkit was not getting the CSS applied:

![image](https://cloud.githubusercontent.com/assets/355079/6105779/d5e66590-b052-11e4-978b-3386a54d66b8.png)

Now it is:

![image](https://cloud.githubusercontent.com/assets/355079/6105785/e50841f6-b052-11e4-811b-0967b6ccd694.png)

Also brings in the change to the summary page from #24.