### PR TITLE
Use class naming conventions on summary page

### DIFF
--- a/pages_builder/pages/forms/summary.yml
+++ b/pages_builder/pages/forms/summary.yml
@@ -2,6 +2,7 @@ pageTitle: Summary - Forms - Test toolkit
 assetPath: ../govuk_template/assets/
 head: >
   <link rel="stylesheet" media="all" type="text/css" href="../public/stylesheets/index.css" />
+  <link rel="stylesheet" media="all" type="text/css" href="../public/stylesheets/forms/summary.css" />
   <!--[if gt IE 8]><!-->
     <link rel="stylesheet" media="all" type="text/css" href="../public/stylesheets/forms/index.css" />
   <!--<![endif]-->
@@ -41,7 +42,7 @@ content: >
       <h2 class="summary-item-heading">
           Summary item
       </h2>
-      <table class="summary-item">
+      <table class="summary-item-body">
         <thead class="summary-item-field-headings">
           <tr>
             <th scope="col">
@@ -52,12 +53,12 @@ content: >
             </th>
           </tr>
         </thead>
-        <tbody class="summary-item-body">
+        <tbody class="summary-item">
           <tr class="summary-item-row">
-            <td class="summary-item-name-field">
+            <td class="summary-item-field-name">
               <span>Summary item name</span>
             </td>
-            <td class="summary-item-content-field">
+            <td class="summary-item-field-content">
               Summary item content
             </td>
             <td class="summary-item-action-field">
@@ -72,7 +73,7 @@ content: >
       <p class="summary-item-top-level-action">
         <a href="" class="summary-change-link">Edit <span class="visuallyhidden"> Summary item with action</span></a>
       </p>
-      <table class="summary-item">
+      <table class="summary-item-body">
         <thead class="summary-item-field-headings">
           <tr>
             <th scope="col">
@@ -83,12 +84,12 @@ content: >
             </th>
           </tr>
         </thead>
-        <tbody class="summary-item-body">
+        <tbody>
           <tr class="summary-item-row">
-            <td class="summary-item-name-field">
+            <td class="summary-item-field-name">
               <span>Summary item name</span>
             </td>
-            <td class="summary-item-content-field">
+            <td class="summary-item-field-content">
               Summary item content
             </td>
             <td class="summary-item-action-field">
@@ -101,7 +102,7 @@ content: >
           <span class="summary-item-heading-number">1.</span>
           Summary item with number
       </h2>
-      <table class="summary-item">
+      <table class="summary-item-body">
         <thead class="summary-item-field-headings">
           <tr>
             <th scope="col">
@@ -112,12 +113,12 @@ content: >
             </th>
           </tr>
         </thead>
-        <tbody class="summary-item-body">
+        <tbody>
           <tr class="summary-item-row">
-            <td class="summary-item-name-field">
+            <td class="summary-item-field-name">
               <span>Summary item name</span>
             </td>
-            <td class="summary-item-content-field">
+            <td class="summary-item-field-content">
               Summary item content
             </td>
             <td class="summary-item-action-field">
@@ -129,7 +130,7 @@ content: >
       <h2 class="summary-item-heading">
           Summary item with name field as link
       </h2>
-      <table class="summary-item">
+      <table class="summary-item-body">
         <thead class="summary-item-field-headings">
           <tr>
             <th scope="col">
@@ -140,12 +141,12 @@ content: >
             </th>
           </tr>
         </thead>
-        <tbody class="summary-item-body">
+        <tbody>
           <tr class="summary-item-row">
-            <td class="summary-item-name-field">
+            <td class="summary-item-field-name">
               <a href="">Summary item name</a>
             </td>
-            <td class="summary-item-content-field">
+            <td class="summary-item-field-content">
               Summary item content
             </td>
             <td class="summary-item-action-field">
@@ -157,7 +158,7 @@ content: >
       <h2 class="summary-item-heading">
           Summary item with content field as list
       </h2>
-      <table class="summary-item">
+      <table class="summary-item-body">
         <thead class="summary-item-field-headings">
           <tr>
             <th scope="col">
@@ -168,12 +169,12 @@ content: >
             </th>
           </tr>
         </thead>
-        <tbody class="summary-item-body">
+        <tbody class="summary-item">
           <tr class="summary-item-row">
-            <td class="summary-item-name-field">
+            <td class="summary-item-field-name">
               <span>Summary item name</span>
             </td>
-            <td class="summary-item-content-field">
+            <td class="summary-item-field-content">
               <ul>
                 <li>Summary item content 1</li>
                 <li>Summary item content 2</li>
@@ -188,7 +189,7 @@ content: >
       <h2 class="summary-item-heading">
           Summary item with incomplete entry
       </h2>
-      <table class="summary-item">
+      <table class="summary-item-body">
         <thead class="summary-item-field-headings">
           <tr>
             <th scope="col">
@@ -199,16 +200,16 @@ content: >
             </th>
           </tr>
         </thead>
-        <tbody class="summary-item-body">
-          <tr class="summary-item-row summary-item-row-incomplete">
-            <td class="summary-item-name-field">
+        <tbody class="summary-item">
+          <tr class="summary-item-row-incomplete">
+            <td class="summary-item-field-name">
               <span>Summary item name</span>
             </td>
-            <td class="summary-item-content-field">
-              <a href="">Summary item content</a>
+            <td class="summary-item-field-content">
+              <a href="#">Summary item content</a>
             </td>
             <td class="summary-item-action-field">
-              <a href="">Change<span class="visuallyhidden"> Summary item</span></a>
+              <a href="#">Change<span class="visuallyhidden"> Summary item</span></a>
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
_This pull request replaces #25 (same changes, but against `master` not `gh-pages`)._

The naming of classes used in the markup did not quite fit with the [naming convention](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/tree/master/scss#naming).

This meant that the summary page in the toolkit was not getting the CSS applied.

| Before | After |
---|---
| ![image](https://cloud.githubusercontent.com/assets/355079/6105779/d5e66590-b052-11e4-978b-3386a54d66b8.png) | ![image](https://cloud.githubusercontent.com/assets/355079/6105785/e50841f6-b052-11e4-811b-0967b6ccd694.png) |