### PR TITLE
Add smaller page headings

### DIFF
--- a/pages_builder/pages/page-headings/page-heading-smaller.yml
+++ b/pages_builder/pages/page-headings/page-heading-smaller.yml
@@ -9,27 +9,22 @@ content: >
         <li>
           <a href="../">Home</a>
         </li>
+        <li>
+          <a href="./">Page headings</a>
+        </li>
       </ol>
     </nav>
   </div>
   <main role="main" id="content" class="wrapper">
     <div id="wrapper">
-      <header class="page-heading">
-        <h1>Page headings</h1>
+      <header class="page-heading-smaller">
+        <h1>Page heading (smaller)</h1>
       </header>
-      <ul>
-        <li>
-          <a href="page-heading.html">Page heading</a>
-        </li>
-        <li>
-          <a href="page-heading-no-breadcrumb.html">Page heading, no breadcrumb</a>
-        </li>
-        <li>
-          <a href="page-heading-with-context.html">Page heading with context</a>
-        </li>
-        <li>
-          <a href="page-heading-smaller.html">Page heading (smaller)</a>
-        </li>
-      </ul>
+      <header class="page-heading-smaller">
+        <p class="context">
+          Context
+        </p>
+        <h1>Page heading (smaller)</h1>
+      </header>
     </div>
   </main>

--- a/toolkit/scss/_page-headings.scss
+++ b/toolkit/scss/_page-headings.scss
@@ -30,3 +30,13 @@
     margin-top: ($gutter * 1.5) + 44px;
   }
 }
+
+.page-heading-smaller {
+
+  @extend %page-heading;
+
+  h1 {
+    @include bold-36;
+  }
+
+}


### PR DESCRIPTION
There are some places on the Marketplace that use 36px type for page headings rather than 48px. This is typically where the headings have text of a greater length: 

-------
| ![screen shot 2015-02-19 at 08 54 59](https://cloud.githubusercontent.com/assets/355079/6263860/64e7f8fc-b815-11e4-9378-393b8111db99.png)| 
---


This commit adds a `page-heading-smaller` class which can be used instead of `page heading`. The resulting example looks like this:

---
|![screen shot 2015-02-19 at 08 54 43](https://cloud.githubusercontent.com/assets/355079/6263866/7326860e-b815-11e4-836c-aefa829a2b15.png)|
---
