### PR TITLE
Add the version to the main index page when built

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ pip install -r ./pages_builder/requirements.txt
 ### Generate the pages locally
 
 ```
-python build_tools/generate_pages.py
+python pages_builder/generate_pages.py
 ```
 
 ### Run the server

--- a/pages_builder/generate_pages.py
+++ b/pages_builder/generate_pages.py
@@ -27,6 +27,9 @@ class Styleguide_publisher(object):
     self.copy_javascripts()
     self.copy_images()
 
+  def get_version(self):
+    return open(os.path.join(self.repo_root, "VERSION.txt")).read().rstrip()
+
   def get_template_folder(self):
     template_handler = TemplateHandler()
     if template_handler.needs_update():
@@ -61,6 +64,10 @@ class Styleguide_publisher(object):
   def render_page(self, input_file):
     output_file = self.__get_page_filename(input_file)
     partial = yaml.load(open(input_file, "r").read())
+    # if the main index page, add the version number from the VERSION.txt file
+    if self.__is_main_index(output_file):
+      partial['content'] = pystache.render(partial['content'], { "version" : self.get_version() })
+
     page_render = pystache.render(self.template_view, partial)
     print "\n  " + input_file
     print "▸ " + output_file
@@ -93,6 +100,9 @@ class Styleguide_publisher(object):
   def __is_yaml(self, file):
     filename, extension = os.path.splitext(file)
     return extension == ".yml"
+
+  def __is_main_index(self, filename):
+    return filename == os.path.join(self.repo_root, "pages/index.html")
 
 if __name__ == "__main__":
   styleguide_publisher = Styleguide_publisher()

--- a/pages_builder/pages/index.yml
+++ b/pages_builder/pages/index.yml
@@ -6,7 +6,7 @@ content: >
   <main role="main" id="content" class="wrapper">
     <div id="wrapper">
       <header class="page-heading page-heading-no-breadcrumb">
-        <h1>Digital Marketplace front end toolkit</h1>
+        <h1>Digital Marketplace front end toolkit, version {{ version }}</h1>
       </header>
       <ul>
         <li><a href="beta-banner.html">Beta banner</a></li>


### PR DESCRIPTION
This was previously part of the task that pushed to Github pages, now part of the task that builds the pages.

Includes a fix to the README docs.