### PR TITLE
Add missing Javascripts for selection buttons

### DIFF
--- a/pages_builder/generate_pages.py
+++ b/pages_builder/generate_pages.py
@@ -74,6 +74,7 @@ class Styleguide_publisher(object):
     print "\nCOPYING JAVASCRIPTS\n"
     dir_util.copy_tree("toolkit/javascripts", "pages/public/javascripts")
     dir_util.copy_tree("pages_builder/assets/javascripts", "pages/public/javascripts/")
+    dir_util.copy_tree("pages_builder/govuk_frontend_toolkit/javascripts", "pages/public/javascripts/govuk_frontend_toolkit/")
     print "★ Done"
 
   def copy_images(self):

--- a/pages_builder/pages/forms/selection-buttons.yml
+++ b/pages_builder/pages/forms/selection-buttons.yml
@@ -5,8 +5,8 @@ head: >
   <link rel="stylesheet" media="all" type="text/css" href="../public/stylesheets/forms/index.css" />
 bodyEnd: >
   <script type="text/javascript" src="../public/javascripts/vendor/jquery-1.11.0.js"></script>
-  <script type="text/javascript" src="../govuk_frontend_toolkit/javascripts/vendor/polyfills/bind.js"></script>
-  <script type="text/javascript" src="../govuk_frontend_toolkit/javascripts/govuk/selection-buttons.js"></script>
+  <script type="text/javascript" src="../public/javascripts/govuk_frontend_toolkit/vendor/polyfills/bind.js"></script>
+  <script type="text/javascript" src="../public/javascripts/govuk_frontend_toolkit/govuk/selection-buttons.js"></script>
   <script type="text/javascript" src="../public/javascripts/onready.js"></script>
 content: >
   <div id="global-breadcrumb" class="header-context">


### PR DESCRIPTION
The [selection buttons page](http://alphagov.github.io/digitalmarketplace-frontend-toolkit/forms/selection-buttons.html) was missing some required Javascript files because they weren't getting copied into the `./pages` folder when generating the documentation.

This commit modifies `generate_pages.py` to copy all the Javascript files provided by GOV.UK front end toolkit. Pages can then add relevant `<script>` tags as and when required.

Before | After
---|---
![screen shot 2015-02-19 at 16 56 45](https://cloud.githubusercontent.com/assets/355079/6271447/8fdc5678-b858-11e4-93e8-5835f282fb6d.png) | ![screen shot 2015-02-19 at 16 57 32](https://cloud.githubusercontent.com/assets/355079/6271456/962474a2-b858-11e4-95c0-dbed7b985221.png)
