### PR TITLE
Remove old code, make commit message fit 80 chars

### DIFF
--- a/pages_builder/push_to_github_pages.sh
+++ b/pages_builder/push_to_github_pages.sh
@@ -43,11 +43,10 @@ echo "--------------------------------------------------------------------------
 rm -rf ./*
 cd ..
 python ./pages_builder/generate_pages.py
-#sed "s/<h1>(.*)</h1>/<h1>Digital Marketplace Frontend Toolkit @ $build_from</h1>/g" pages/index.html > pages/index.html
 echo "--------------------------------------------------------------------------------"
 echo "Commiting changes to generated pages"
 echo "--------------------------------------------------------------------------------"
 cd pages
 git add .
-git commit --allow-empty -m "Publishing Digital Marketplace Frontend Toolkit documentation from $build_from"
+git commit --allow-empty -m "Publish documentation from $build_from"
 git push origin $destination_branch


### PR DESCRIPTION
This commit:
- Removes the line from the publish script which used to add the toolkit version to the docs home page – this is now done using Pystache
- Makes the commit message under 80 characters so that it doesn't get truncated in Github

No more of this:
![image](https://cloud.githubusercontent.com/assets/355079/6332511/e4e9508a-bb7d-11e4-9250-e7b89175b9c6.png)
