### PR TITLE
Add option to serve pages from a subfolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ The documentation can be accessed at [http://alphagov.github.io/digitalmarketpla
 
 ### Static assets
 
-The pages use `pages` as the root directory so you can include any assets from `./pages/public/javascripts` or `./pages/public/images` directly.
+The pages use `pages` as the root directory so you can include any assets from `/pages/public/javascripts` or `/pages/public/images` directly. If `pages` is not your root directory then you need to set the path to
+'pages' in an environment variable, eg: `ROOT_DIRECTORY='/digitalmarketplace-frontend-toolkit'`
 
 ### Example markup
 

--- a/pages_builder/generate_pages.py
+++ b/pages_builder/generate_pages.py
@@ -67,24 +67,25 @@ class Styleguide_publisher(object):
     # if the main index page, add the version number from the VERSION.txt file
     if self.__is_main_index(output_file):
       partial['content'] = pystache.render(partial['content'], { "version" : self.get_version() })
+    root = os.getenv("ROOT_DIRECTORY") or ""
 
-    partial['head'] = """
-        <!--[if !IE]><!-->
-        <link rel="stylesheet" href="/public/stylesheets/index.css "/>
-        <!--<![endif]-->
-        <!--[if IE 6]>
-        <link rel="stylesheet" href="/public/stylesheets/index-ie6.css "/>
-        <![endif]-->
-        <!--[if IE 7]>
-        <link rel="stylesheet" href="/public/stylesheets/index-ie7.css "/>
-        <![endif]-->
-        <!--[if IE 8]>
-        <link rel="stylesheet" href="/public/stylesheets/index-ie8.css "/>
-        <![endif]-->
-        <!--[if IE 9]>
-        <link rel="stylesheet" href="/public/stylesheets/index-ie9.css "/>
-        <![endif]-->
-    """
+    partial['head'] = (
+        '<!--[if !IE]><!-->'
+        '<link rel="stylesheet" href="' + root + '/public/stylesheets/index.css "/>'
+        '<!--<![endif]-->'
+        '<!--[if IE 6]>'
+        '<link rel="stylesheet" href="' + root + '/public/stylesheets/index-ie6.css "/>'
+        '<![endif]-->'
+        '<!--[if IE 7]>'
+        '<link rel="stylesheet" href="' + root + '/public/stylesheets/index-ie7.css "/>'
+        '<![endif]-->'
+        '<!--[if IE 8]>'
+        '<link rel="stylesheet" href="' + root + '/public/stylesheets/index-ie8.css "/>'
+        '<![endif]-->'
+        '<!--[if IE 9]>'
+        '<link rel="stylesheet" href="' + root + '/public/stylesheets/index-ie9.css "/>'
+        '<![endif]-->'
+    )
     page_render = pystache.render(self.template_view, partial)
     print "\n  " + input_file
     print "▸ " + output_file


### PR DESCRIPTION
**This fixes a bug where we have no app CSS on Github Pages.**

We now have absolute paths for all assets served from `pages/public`.

By default, running `python -m SimpleHTTPServer 8000` in the `pages/` directory will JustWork™.

If the root directory is different (eg on Github pages) you can set an optional environment variable (`ROOT_DIRECTORY='/digitalmarketplace-frontend-toolkit'`) which gets prepended to the path to any CSS file. The [Jenkins job](http://37.26.90.26:8080/job/Publish%20toolkit%20documentation/configure) has already been configured to provide this.