### PR TITLE
Make all inline-block CSS use mixin

### DIFF
--- a/toolkit/scss/_search-result.scss
+++ b/toolkit/scss/_search-result.scss
@@ -1,6 +1,7 @@
 @import "_colours.scss";
 @import "_typography.scss";
 @import "_measurements.scss";
+@import "_shims.scss";
 
 .search-result {
   margin: 0;
@@ -25,7 +26,7 @@
 
 .search-result-highlighted-text {
   padding: 0 2px;
-  display: inline-block;
+  @include inline-block;
   background-color: $yellow-25;
   background-image: file-url('search-result-highlight-mask.png');
   background-position: 0 -6px;
@@ -39,7 +40,7 @@
 
 .search-result-metadata-item {
   list-style: none;
-  display: inline-block;
+  @include inline-block;
   background: $highlight-colour;
   border: 1px dotted $grey-3;
   padding: 2px 6px;

--- a/toolkit/scss/forms/_textboxes.scss
+++ b/toolkit/scss/forms/_textboxes.scss
@@ -2,6 +2,7 @@
 @import "_conditionals.scss";
 @import "_typography.scss";
 @import "_css3.scss";
+@import "_shims.scss";
 
 .text-box {
   @include core-19;
@@ -26,14 +27,14 @@
 }
 
 .text-box-percentage {
-  display: inline-block;
+  @include inline-block;
   width: 6em;
   text-align: right;
   padding-right: 5px;
 }
 
 .text-box-percentage-label {
-  display: inline-block;
+  @include inline-block;
   @include core-19;
 }
 


### PR DESCRIPTION
The mixin allows it to work on older versions of IE.