### PR TITLE
Make search result look closer to GOV.UK finders

### DIFF
--- a/toolkit/scss/_search-result.scss
+++ b/toolkit/scss/_search-result.scss
@@ -4,24 +4,34 @@
 @import "_shims.scss";
 
 .search-result {
-  margin: 0;
-  padding: 0 0 $gutter 0;
+
+  padding: 0 0 $gutter/2;
+  margin: 0 0 $gutter/2;
+
+  border-bottom: 1px solid $border-colour;
+
 }
 
 .search-result-title {
-  @include heading-24;
+
+  @include core-19;
+  font-weight: bold;
   margin: 0;
+
+  a {
+    text-decoration: none;
+  }
+
 }
 
 .search-result-supplier {
-  @include copy-19;
-  color: $secondary-text-colour;
-  margin: 0;
+  @include core-16;
+  margin: 5px 0 0 0;
 }
 
 .search-result-excerpt {
-  @include copy-19;
-  margin: 0;
+  @include core-16;
+  margin: 5px 0 0 0;
 }
 
 .search-result-highlighted-text {
@@ -29,21 +39,18 @@
   @include inline-block;
   background-color: $yellow-25;
   background-image: file-url('search-result-highlight-mask.png');
-  background-position: 0 -6px;
+  background-position: 0 -8px;
   background-repeat: repeat;
 }
 
 .search-result-metadata {
-  margin: 5px 0 0 0;
+  margin: 0 0 0 0;
   padding: 0;
 }
 
 .search-result-metadata-item {
   list-style: none;
   @include inline-block;
-  background: $highlight-colour;
-  border: 1px dotted $grey-3;
-  padding: 2px 6px;
-  margin: 0 4px 0 0;
-  @include core-16;
+  margin: 5px 10px 0 0;
+  @include core-14;
 }

--- a/toolkit/scss/_search-result.scss
+++ b/toolkit/scss/_search-result.scss
@@ -14,8 +14,7 @@
 
 .search-result-title {
 
-  @include core-19;
-  font-weight: bold;
+  @include bold-19;
   margin: 0;
 
   a {
@@ -44,7 +43,7 @@
 }
 
 .search-result-metadata {
-  margin: 0 0 0 0;
+  margin: 0;
   padding: 0;
 }
 


### PR DESCRIPTION
In reviewing the design of the Digital Marketplace it was pointed out that search results could make use of the existing 'finder' pattern on GOV.UK (eg
https://www.gov.uk/drug-device-alerts) which would increase the information density of the page.

We will also be using this pattern on forthcoming pages, eg supplier profile, so now is a good time to change it.

This commit adjusts the `.search-result` to look like a GOV.UK finder, if a GOV.UK finder had a line for 'supplier'.

Before | After
--- | ---
![image](https://cloud.githubusercontent.com/assets/355079/6663952/538f9f58-cbc3-11e4-8247-02f69e5fcb3c.png) |  ![image](https://cloud.githubusercontent.com/assets/355079/6663959/5d17e5f8-cbc3-11e4-8998-742cff0e40dd.png)
