### PR TITLE
Add: link to release, breadcrumbs, scroll overflow

### DIFF
--- a/pages_builder/assets/scss/index.scss
+++ b/pages_builder/assets/scss/index.scss
@@ -1,35 +1,6 @@
 $path : '../images/';
 @import "grids/index.scss";
-
-#wrapper {
-  @extend %site-width-container;
-}
-
-pre {
-
-  box-shadow: inset 0 0 50px 0 rgba(50, 20, 0, .025);
-  background: rgb(250, 250, 250);
-  padding: 10px 10px 15px 15px;
-  font-family: monospace;
-  font-size: 17px;
-  margin-bottom: 30px;
-  color: #888;
-  position: relative;
-
-  &:hover {
-    color: #111;
-  }
-
-  &:before {
-    content: "HTML";
-    position: absolute;
-    top: 10px;
-    right: 15px;
-    color: rgba(0, 0, 0, .15);
-    letter-spacing: 3px;
-  }
-
-}
+@import "colours";
 
 // Toolkit components
 @import "_phase-banner.scss";
@@ -50,3 +21,59 @@ pre {
 @import "forms/_textboxes.scss";
 @import "forms/_validation.scss";
 @import "forms/_word-counter.scss";
+
+
+#wrapper {
+  @extend %site-width-container;
+}
+
+pre {
+
+  box-shadow: inset 0 0 50px 0 rgba(50, 20, 0, .025);
+  background: rgb(250, 250, 250);
+  padding: 10px 10px 15px 15px;
+  font-family: monospace;
+  font-size: 17px;
+  margin-bottom: 30px;
+  color: #888;
+  position: relative;
+  overflow: scroll;
+
+  &:hover {
+    color: #111;
+  }
+
+  &:before {
+    content: "HTML";
+    position: absolute;
+    top: 10px;
+    right: 15px;
+    color: rgba(0, 0, 0, .15);
+    letter-spacing: 3px;
+  }
+
+}
+
+a.version-link {
+
+  &:link {
+    text-decoration: none;
+  }
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+}
+
+.index-list {
+
+  @include core-19;
+  padding: 0 0 $gutter*2 0;
+
+  li {
+    margin-bottom: 5px;
+    list-style: none;
+  }
+
+}

--- a/pages_builder/generate_pages.py
+++ b/pages_builder/generate_pages.py
@@ -82,13 +82,27 @@ class Styleguide_publisher(object):
                 partial['content'], {"version": self.get_version()}
             )
         else:
+            partial['pageHeading'] = partial['pageTitle']
+            partial['pageTitle'] = (
+                partial['pageTitle'] +
+                " - Digital Marketplace frontend toolkit"
+            )
             if "examples" in partial:
                 partial['content'] = pystache.render(
                     """
+                        <div id="global-breadcrumb" class="header-context">
+                          <nav>
+                            <ol class="group" role="breadcrumbs">
+                              <li>
+                                <a href="/">Home</a>
+                              </li>
+                            </ol>
+                          </nav>
+                        </div>
                         <main role="main" id="content" class="wrapper">
                             <div id="wrapper">
                                 <header class="page-heading">
-                                    <h1>{{pageTitle}}</h1>
+                                    <h1>{{pageHeading}}</h1>
                                 </header>
                                 {{#examples}}
                                     {{#title}}<h2>{{title}}</h2>{{/title}}
@@ -99,7 +113,8 @@ class Styleguide_publisher(object):
                         </main>
                     """, {
                         "examples": partial['examples'],
-                        "pageTitle": partial['pageTitle']
+                        "pageTitle": partial['pageTitle'],
+                        "pageHeading": partial['pageHeading']
                     }
                 )
         root = os.getenv("ROOT_DIRECTORY") or ""

--- a/pages_builder/pages/forms/index.yml
+++ b/pages_builder/pages/forms/index.yml
@@ -1,24 +1,12 @@
-pageTitle: Textboxes - Forms - Test toolkit
+pageTitle: Forms
 assetPath: ../govuk_template/assets/
 content: >
-  <div id="global-breadcrumb" class="header-context">
-    <nav>
-      <ol class="group" role="breadcrumbs">
-        <li>
-          <a href="../">Home</a>
-        </li>
-        <li>
-          Forms
-        </li>
-      </ol>
-    </nav>
-  </div>
   <main role="main" id="content" class="wrapper">
     <div id="wrapper">
       <header class="page-heading">
         <h1>Forms</h1>
       </header>
-      <ul>
+      <ul class="index-list">
         <li>
           <a href="textboxes.html">Textboxes</a>
         </li>

--- a/pages_builder/pages/forms/list-entry.yml
+++ b/pages_builder/pages/forms/list-entry.yml
@@ -1,4 +1,4 @@
-pageTitle: List entry textbox - Forms - Test toolkit
+pageTitle: List entry
 assetPath: ../govuk_template/assets/
 bodyEnd: >
   <script type="text/javascript" src="../public/javascripts/vendor/jquery-1.11.0.js"></script>
@@ -8,7 +8,6 @@ bodyEnd: >
   <script type="text/javascript" src="../public/javascripts/onready.js"></script>
 examples:
   -
-    title: List entry
     markup: >
       <fieldset class="question first-question" id="p5q1">
         <legend class="question-heading  question-heading-with-hint ">

--- a/pages_builder/pages/forms/option-select.yml
+++ b/pages_builder/pages/forms/option-select.yml
@@ -1,4 +1,4 @@
-pageTitle: Option selects
+pageTitle: Option select
 assetPath: ../govuk_template/assets/
 bodyEnd: >
   <script type="text/javascript" src="../public/javascripts/vendor/jquery-1.11.0.js"></script>

--- a/pages_builder/pages/index.yml
+++ b/pages_builder/pages/index.yml
@@ -1,12 +1,15 @@
-pageTitle: Test toolkit
+pageTitle: Digital Marketplace frontend toolkit
 assetPath: govuk_template/assets/
 content: >
   <main role="main" id="content" class="wrapper">
     <div id="wrapper">
       <header class="page-heading page-heading-no-breadcrumb">
-        <h1>Digital Marketplace front end toolkit, version {{ version }}</h1>
+        <p class="context">
+          <a class="version-link" href="https://github.com/alphagov/digitalmarketplace-frontend-toolkit/releases/tag/v{{ version }}">Version {{ version }}</a>
+        </p>
+        <h1>Digital Marketplace frontend toolkit</h1>
       </header>
-      <ul>
+      <ul class="index-list">
         <li><a href="beta-banner.html">Beta banner</a></li>
         <li><a href="breadcrumb.html">Breadcrumb</a></li>
         <li><a href="page-headings.html">Page headings</a></li>


### PR DESCRIPTION
This commit is mainly just tidying up. It:
- Adds a link to the release for the current version
- Adds a 'home' breadcrumb to every page
- Makes the code samples horizontal scroll if they overflow the container (as requested in user research)
- Rationalises page `<title>`s and removes references to "test toolkit"

![image](https://cloud.githubusercontent.com/assets/355079/6851302/294742e4-d3d6-11e4-9771-ab60a0f94bca.png)

![image](https://cloud.githubusercontent.com/assets/355079/6851308/35bc3fca-d3d6-11e4-842a-b8f9f3805899.png)

![image](https://cloud.githubusercontent.com/assets/355079/6851349/6df2e0ba-d3d6-11e4-9dcb-d6ba3d676645.png)

