### PR TITLE
Remove dependency on SSP naming of list items

### DIFF
--- a/pages_builder/pages/forms/list-entry.yml
+++ b/pages_builder/pages/forms/list-entry.yml
@@ -9,73 +9,73 @@ bodyEnd: >
 examples:
   -
     markup: >
-      <fieldset class="question first-question" id="p5q1">
+      <fieldset class="question first-question" id="feature">
         <legend class="question-heading  question-heading-with-hint ">
           Service features
         </legend>
         <p class="hint">
           Include the technical features of your product, eg graphical workflow, remote access. (Maximum 10 words per feature. Maximum 10 features.)
         </p>
-        <div class="input-list" data-list-item-name="feature">
+        <div class="input-list" data-list-item-name="feature" id="list-entry-feature">
           <div class="list-entry">
             <label for="p1q1val1" class="text-box-number-label">
               <span class="visuallyhidden">feature number </span>1.
             </label>
-            <input type="text" name="p1q1val1" id="p1q1val1" class="text-box" value="" />
+            <input type="text" name="feature" id="feature-1" class="text-box" value="" />
           </div>
           <div class="list-entry">
             <label for="p1q1val2" class="text-box-number-label">
               <span class="visuallyhidden">feature number </span>2.
             </label>
-            <input type="text" name="p1q1val2" id="p1q1val2" class="text-box" value="" />
+            <input type="text" name="feature" id="feature-2" class="text-box" value="" />
           </div>
           <div class="list-entry">
             <label for="p1q1val3" class="text-box-number-label">
               <span class="visuallyhidden">feature number </span>3.
             </label>
-            <input type="text" name="p1q1val3" id="p1q1val3" class="text-box" value="" />
+            <input type="text" name="feature" id="feature-3" class="text-box" value="" />
           </div>
           <div class="list-entry">
             <label for="p1q1val4" class="text-box-number-label">
               <span class="visuallyhidden">feature number </span>4.
             </label>
-            <input type="text" name="p1q1val4" id="p1q1val4" class="text-box" value="" />
+            <input type="text" name="feature" id="feature-4" class="text-box" value="" />
           </div>
           <div class="list-entry">
             <label for="p1q1val5" class="text-box-number-label">
               <span class="visuallyhidden">feature number </span>5.
             </label>
-            <input type="text" name="p1q1val5" id="p1q1val5" class="text-box" value="" />
+            <input type="text" name="feature" id="feature-5" class="text-box" value="" />
           </div>
           <div class="list-entry">
             <label for="p1q1val6" class="text-box-number-label">
               <span class="visuallyhidden">feature number </span>6.
             </label>
-            <input type="text" name="p1q1val6" id="p1q1val6" class="text-box" value="" />
+            <input type="text" name="feature" id="feature-6" class="text-box" value="" />
           </div>
           <div class="list-entry">
             <label for="p1q1val7" class="text-box-number-label">
               <span class="visuallyhidden">feature number </span>7.
             </label>
-            <input type="text" name="p1q1val7" id="p1q1val7" class="text-box" value="" />
+            <input type="text" name="feature" id="feature-7" class="text-box" value="" />
           </div>
           <div class="list-entry">
             <label for="p1q1val8" class="text-box-number-label">
               <span class="visuallyhidden">feature number </span>8.
             </label>
-            <input type="text" name="p1q1val8" id="p1q1val8" class="text-box" value="" />
+            <input type="text" name="feature" id="feature-8" class="text-box" value="" />
           </div>
           <div class="list-entry">
             <label for="p1q1val9" class="text-box-number-label">
               <span class="visuallyhidden">feature number </span>9.
             </label>
-            <input type="text" name="p1q1val9" id="p1q1val9" class="text-box" value="" />
+            <input type="text" name="feature" id="feature-9" class="text-box" value="" />
           </div>
           <div class="list-entry">
             <label for="p1q1val10" class="text-box-number-label">
               <span class="visuallyhidden">feature number </span>10.
             </label>
-            <input type="text" name="p1q1val10" id="p1q1val10" class="text-box" value="" />
+            <input type="text" name="feature0" id="feature-10" class="text-box" value="" />
           </div>
         </div>
       </fieldset>

--- a/spec/unit/ListEntrySpec.js
+++ b/spec/unit/ListEntrySpec.js
@@ -1,17 +1,20 @@
 describe("ListEntryField", function () {
-  var entryFieldTemplate = Hogan.compile('<div class="list-entry">' +
-                                          '<label for="{{{id}}}" class="text-box-number-label">' +
-                                            '<span class="hidden">Fieldset legend number </span>{{number}}.' +
-                                          '</label>' +
-                                          '<input type="text" name="{{{id}}}" id="{{{id}}}" class="text-box" value="">' +
-                                        '</div>'
-                            ),
-      wrapperHTML = '<div class="input-list" data-list-item-name="feature">' +
-                      '<fieldset class="question">' +
-                        '<legend class="question-heading question-heading-with-hint ">Service features</legend>' +
-                        '<p class="question-hint">Include the technical features of your product, eg graphical workflow, remote access. (Maximum 10 words per feature. Maximum 10 features.)</p>' +
-                      '</fieldset>' +
-                    '</div>',
+  var entryFieldTemplate = Hogan.compile(
+        '<div class="list-entry">' +
+          '<label for="{{{id}}}" class="text-box-number-label">' +
+            '<span class="hidden">Item number </span>{{number}}.' +
+          '</label>' +
+          '<input type="text" name="{{{name}}}" id="{{{id}}}" class="text-box" value="">' +
+        '</div>'
+      ),
+      wrapperHTML = (
+          '<fieldset class="question" id="features">' +
+            '<legend class="question-heading question-heading-with-hint ">Service features</legend>' +
+            '<p class="question-hint">Include the technical features of your product, eg graphical workflow, remote access. (Maximum 10 words per feature. Maximum 10 features.)</p>' +
+            '<div class="input-list" data-list-item-name="feature" id="list-entry-features">' +
+            '</div>' +
+          '</fieldset>'
+      ),
       $wrapper,
       mock4Entries;
 
@@ -23,12 +26,14 @@ describe("ListEntryField", function () {
   };
 
   beforeEach(function () {
+    var idx;
     $wrapper = $(wrapperHTML);
 
     for (idx in [1,2,3,4,5,6,7,8,9,10]) {
-      $wrapper.append(entryFieldTemplate.render({
-        'id' : 'p1q1val' + idx,
-        'number' : idx
+      $wrapper.find(".input-list").append(entryFieldTemplate.render({
+        'name': 'features',
+        'id': 'features-' + idx,
+        'number': idx
       }));
     }
     $(document.body).append($wrapper);

--- a/toolkit/javascripts/list-entry.js
+++ b/toolkit/javascripts/list-entry.js
@@ -11,7 +11,7 @@
 
   ListEntry = function (elm) {
     var $elm = $(elm),
-        idPattern = this.getIdPattern($elm.find('input')[0]);
+        idPattern = $elm.prop('id');
 
     if (!idPattern) { return false; }
     this.idPattern = idPattern;
@@ -76,7 +76,12 @@
     this.entries = newEntries.reverse();
   };
   ListEntry.prototype.getId = function (num) {
-    return this.idPattern + num;
+    var pattern = this.idPattern.replace("list-entry-", "");
+    if ("undefined" === typeof num) {
+      return pattern;
+    } else {
+      return pattern + "-" + num;
+    }
   };
   ListEntry.prototype.bindEvents = function () {
     this.$wrapper.on('click', '.list-entry-remove', function (e) {
@@ -131,7 +136,7 @@
           dataObj = {
             'id' : this.getId(entryNumber),
             'number' : entryNumber,
-            'name' : this.getId(entryNumber),
+            'name' : this.getId(),
             'value' : entry,
             'listItemName' : this.listItemName
           };


### PR DESCRIPTION
The SSP expected the `name` attribute of list items to be in the format 'p1q5val1'.

Flask (and others) can provide an array of items if the request contains a series of values with the same key, ie from a series of `input`s with the same `name` attribute.

This commit removes the dependency on the naming convention used in the SSP.