### PR TITLE
Fix word counter Javascript

### DIFF
--- a/pages_builder/pages/forms/word-count.yml
+++ b/pages_builder/pages/forms/word-count.yml
@@ -2,19 +2,19 @@ pageTitle: Textbox with word count
 assetPath: ../govuk_template/assets/
 bodyEnd: >
   <script type="text/javascript" src="../public/javascripts/vendor/jquery-1.11.0.js"></script>
-  <script type="text/javascript" src="../public/javascripts/vendor/hogan-3.0.2.min.js"></script>
-  <script type="text/javascript" src="../javascripts/list-entry.js"></script>
-  <script type="text/javascript" src="../javascripts/word-counter.js"></script>
+  <script type="text/javascript" src="../public/javascripts/word-counter.js"></script>
   <script type="text/javascript" src="../public/javascripts/onready.js"></script>
 examples:
   -
     markup: >
-      <div class="word-count question first-question">
+      <div class="question first-question">
         <label for="p4q2-text-box" class="question-heading question-heading-with-hint">
           Describe your service
         </label>
         <p class="hint">
           Please provide a short description. (Maximum 50 words.)
         </p>
-        <textarea class="text-box text-box-large" name="question-1" id="question-1" data-max-length-in-words="50"></textarea>
+        <div class="word-count">
+          <textarea class="text-box text-box-large" name="question-1" id="question-1" data-max-length-in-words="50"></textarea>
+        </div>
       </div>


### PR DESCRIPTION
Somewhere along the way the path to the Javascript file for the word counter functionality got pointed to the wrong place.

This commit fixes the path, and revises the markup to show that the `.word-count` class only needs to wrap the `textarea`, not the entire question.