### PR TITLE
Make links in browse list not full width

### DIFF
--- a/toolkit/scss/_browse_list.scss
+++ b/toolkit/scss/_browse_list.scss
@@ -1,6 +1,7 @@
 @import "_colours.scss";
 @import "_typography.scss";
 @import "_measurements.scss";
+@import "_shims.scss";
 
 .browse-list {
   padding: 0;
@@ -12,7 +13,7 @@
 }
 
 .browse-list-item-link {
-  display: block;
+  @include inline-block;
   @include heading-27;
   font-weight: bold;
   text-decoration: none;


### PR DESCRIPTION
So that when you click the links they look like this:
![screen shot 2015-04-08 at 11 01 14](https://cloud.githubusercontent.com/assets/355079/7043112/1a074c6c-dddf-11e4-966e-f20630d8f504.png)

Not this:
![image](https://cloud.githubusercontent.com/assets/355079/7043103/fb0695a2-ddde-11e4-9487-88c3c7e6d3e8.png)
