### PR TITLE
Don't let elements that follow questions float

### DIFF
--- a/toolkit/scss/forms/_questions.scss
+++ b/toolkit/scss/forms/_questions.scss
@@ -3,9 +3,9 @@
 
 .question,
 %question {
+  @extend %contain-floats;
   margin: 15px 0 30px 0;
   clear: both;
-  overflow: hidden;
 }
 
 .question-first {

--- a/toolkit/scss/forms/_questions.scss
+++ b/toolkit/scss/forms/_questions.scss
@@ -3,8 +3,9 @@
 
 .question,
 %question {
-  margin: 15px 0 0 0;
+  margin: 15px 0 30px 0;
   clear: both;
+  overflow: hidden;
 }
 
 .question-first {


### PR DESCRIPTION
If a question contains floated elements then there is a risk that the following elements will float in an undesirable way. This change prevents that.

It also adds some spacing between questions to give them a bit more breathing room.

Example of the problem:

![image](https://cloud.githubusercontent.com/assets/355079/7417693/c05a5be0-ef5f-11e4-8bf1-efa08df38b0a.png)
