### PR TITLE
Narrow left wide right

### DIFF
--- a/toolkit/scss/forms/_summary.scss
+++ b/toolkit/scss/forms/_summary.scss
@@ -90,7 +90,7 @@ table.summary-item-body {
 
 .summary-item-field-name {
   @extend %summary-item-field;
-  width: 50%;
+  width: 33.333%;
   padding-right: 25px;
 }
 
@@ -105,7 +105,7 @@ table.summary-item-body {
 
 .summary-item-field-content {
   @extend %summary-item-field;
-  width: 50%;
+  width: 66.666%;
   padding-left: 25px;
 
   ul {

--- a/toolkit/scss/forms/_summary.scss
+++ b/toolkit/scss/forms/_summary.scss
@@ -88,10 +88,16 @@ table.summary-item-body {
   text-align: left;
 }
 
+%summary-item-field-name,
 .summary-item-field-name {
   @extend %summary-item-field;
   width: 33.333%;
   padding-right: 25px;
+}
+
+.summary-item-field-name-wider {
+  @extend %summary-item-field-name;
+  width: 50%;
 }
 
 .summary-item-field-headings {


### PR DESCRIPTION
Default behaviour for tables to be 1/3 page width for headings and 2/3 for content.

Having a narrower column on the left moves the content closer to the heading. It's easier to read as most of the headings are short (which means there's a unnecessarily large white space between content and heading). It also gives a more comfortable line length for the content column which is mostly the thing you want to spend more time reading and this is much better when the content has bullet points as they are the thing that suffers most if they get wrapped onto two line. On the downside there are some lines where the heading wraps and the content is short, this makes the row taller, but not any harder to read. In most cases it will make the overall page longer, but only by a small amount and on pages that are already long (so users are already scrolling).

The old, non-default behaviour can be retained by changing to use the `.summary-item-field-name-wider` class.