### PR TITLE
Add a pattern for contact details

### DIFF
--- a/pages_builder/assets/scss/index.scss
+++ b/pages_builder/assets/scss/index.scss
@@ -12,6 +12,7 @@ $path : '../images/';
 @import "_page-headings.scss";
 @import "_search-result-wrapper.scss";
 @import "_browse_list.scss";
+@import "_contact-details.scss";
 @import "search/_search-summary.scss";
 @import "forms/_hint.scss";
 @import "forms/_list-entry.scss";

--- a/pages_builder/pages/contact-details.yml
+++ b/pages_builder/pages/contact-details.yml
@@ -1,0 +1,35 @@
+pageTitle: Contact details
+assetPath: govuk_template/assets/
+examples:
+  -
+    markup: >
+      <div class="contact-details" itemscope itemtype="http://schema.org/Organization">
+        <h1 class="contact-details-heading">
+          Contact <span itemprop="name">Government Digital Service</span>
+        </h1>
+        <p class="contact-details-block">
+          <span itemscope itemtype="http://schema.org/Person">
+            <span itemprop="name">
+              Jo Little
+            </span>
+          </span>
+          <span itemprop="telephone">
+            012345 678910
+          </span>
+          <span itemprop="email">
+            <a href="mailto:hello@example.com" data-event-category="Email a supplier" data-event-label="Government Digital Service">hello@example.com</a>
+          </span>
+        </p>
+        <p class="contact-details-block" itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+          <span itemprop="streetAddress">
+            Aviation House<br />
+            125 Kingsway
+          </span>
+          <span itemprop="addressLocality">
+            London
+          </span>
+          <span itemprop="postalCode">
+            WC2B 6NH
+          </span>
+        </p>
+      </div>

--- a/pages_builder/pages/contact-details.yml
+++ b/pages_builder/pages/contact-details.yml
@@ -5,7 +5,7 @@ examples:
     markup: >
       <div class="contact-details" itemscope itemtype="http://schema.org/Organization">
         <h1 class="contact-details-heading">
-          Contact <span itemprop="name">Government Digital Service</span>
+          <span itemprop="name">Government Digital Service</span>
         </h1>
         <p class="contact-details-block">
           <span itemscope itemtype="http://schema.org/Person">
@@ -13,9 +13,13 @@ examples:
               Jo Little
             </span>
           </span>
+        </p>
+        <p class="contact-details-block">
           <span itemprop="telephone">
             012345 678910
           </span>
+        </p>
+        <p class="contact-details-block">
           <span itemprop="email">
             <a href="mailto:hello@example.com" data-event-category="Email a supplier" data-event-label="Government Digital Service">hello@example.com</a>
           </span>

--- a/pages_builder/pages/contact-details.yml
+++ b/pages_builder/pages/contact-details.yml
@@ -2,6 +2,7 @@ pageTitle: Contact details
 assetPath: govuk_template/assets/
 examples:
   -
+    title: Standalone
     markup: >
       <div class="contact-details" itemscope itemtype="http://schema.org/Organization">
         <h1 class="contact-details-heading">
@@ -37,3 +38,39 @@ examples:
           </span>
         </p>
       </div>
+  -
+    title: In a table (without spacing)
+    markup: >
+        <table class="summary-item-body">
+          <thead class="summary-item-field-headings">
+            <tr>
+              <th scope="col">
+                Name
+              </th>
+              <th scope="col">
+                Content
+              </th>
+            </tr>
+          </thead>
+          <tbody class="summary-item">
+            <tr class="summary-item-row">
+              <td class="summary-item-field-name">
+                <span>Address</span>
+              </td>
+              <td class="summary-item-field-content">
+                <p class="contact-details-block-without-spacing" itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+                  <span itemprop="streetAddress">
+                    Aviation House<br />
+                    125 Kingsway
+                  </span>
+                  <span itemprop="addressLocality">
+                    London
+                  </span>
+                  <span itemprop="postalCode">
+                    WC2B 6NH
+                  </span>
+                </p>
+              </td>
+            </tr>
+          </tbody>
+        </table>

--- a/pages_builder/pages/index.yml
+++ b/pages_builder/pages/index.yml
@@ -21,7 +21,8 @@ content: >
         <li><a href="search-summary.html">Search summary</a></li>
         <li><a href="document.html">Documents</a></li>
         <li><a href="browse-list.html">Browse list</a></li>
-        <li><a href="service-id.html">Browse list</a></li>
+        <li><a href="service-id.html">Service ID</a></li>
+        <li><a href="contact-details.html">Contact details</a></li>
       </ul>
     </div>
   </main>

--- a/toolkit/scss/_contact-details.scss
+++ b/toolkit/scss/_contact-details.scss
@@ -1,0 +1,25 @@
+@import "_colours.scss";
+@import "_typography.scss";
+@import "_measurements.scss";
+
+.contact-details-heading {
+  @include copy-16;
+  font-weight: bold;
+  margin: 0;
+}
+
+%contact-details-block,
+.contact-details-block {
+
+  margin: 0 0 $gutter;
+
+  span {
+    display: block;
+  }
+
+}
+
+.contact-details-block-without-spacing {
+  @extend %contact-details-block;
+  margin: 0;
+}

--- a/toolkit/scss/_contact-details.scss
+++ b/toolkit/scss/_contact-details.scss
@@ -3,15 +3,15 @@
 @import "_measurements.scss";
 
 .contact-details-heading {
-  @include copy-16;
+  @include core-16;
   font-weight: bold;
-  margin: 0;
+  margin: 0 0 5px;
 }
 
 %contact-details-block,
 .contact-details-block {
 
-  margin: 0 0 $gutter;
+  margin: 0 0 5px;
 
   span {
     display: block;


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/355079/7963068/bdd286a4-0a08-11e5-8a36-e312e9e4bd31.png)

![image](https://cloud.githubusercontent.com/assets/355079/7971513/1cec9a42-0a3d-11e5-850f-b4044d8f75ab.png)

This is adapted from the contact section of [a service page in the Grails app](https://www.digitalmarketplace.service.gov.uk/service/6574326446817280), but built in such a way that it could be used in other places, eg a supplier's dashboard.

It supplements the markup with microdata as specified by [schema.org/PostalAddress](https://schema.org/PostalAddress).