### PR TITLE
Tweaks to templates

### DIFF
--- a/pages_builder/pages/contact-details.yml
+++ b/pages_builder/pages/contact-details.yml
@@ -8,16 +8,16 @@ examples:
     contact_name: Jo Johnston
     telephone: 012345 678910
     email_address: jo@example.com
-    street_address: >
-      Aviation House<br />
-      125 Kingsway
+    street_address:
+      - line_1: Aviation House
+      - line_2: 125 Kingsway
     locality: London
     postcode: WC2B 6NH
   -
     title: Without spacing (for use in a table, for example)
     without_spacing: true
-    street_address: >
-      Aviation House<br />
-      125 Kingsway
+    street_address:
+      - line_1: Aviation House
+      - line_2: 125 Kingsway
     locality: London
     postcode: WC2B 6NH

--- a/toolkit/templates/contact-details.html
+++ b/toolkit/templates/contact-details.html
@@ -1,9 +1,9 @@
-{% if organisation is defined %}
+{% if organisation %}
 <div class="contact-details" itemscope itemtype="http://schema.org/Organization">
   <p class="contact-details-organisation">
     <span itemprop="name">{{ organisation }}</span>
   </p>
-  {% if contact_name is defined %}
+  {% if contact_name %}
   <p class="contact-details-block">
     <span itemscope itemtype="http://schema.org/Person">
       <span itemprop="name">
@@ -12,14 +12,14 @@
     </span>
   </p>
   {% endif %}
-  {% if telephone is defined %}
+  {% if telephone %}
   <p class="contact-details-block">
     <span itemprop="telephone">
       {{ telephone }}
     </span>
   </p>
   {% endif %}
-  {% if email_address is defined %}
+  {% if email_address %}
   <p class="contact-details-block">
     <span itemprop="email">
       <a href="mailto:{{ email_address }}" data-event-category="Email a {{ organisation_type }}" data-event-label="{{ organisation }}">{{ email_address }}</a>
@@ -28,12 +28,13 @@
   {% endif %}
 {% endif %}
 {% if
-  street_address is defined or
-  locality is defined or
-  postcode is defined
+  street_address or
+  locality or
+  country or
+  postcode
 %}
   <p class="contact-details-block{% if without_spacing %}-without-spacing{% endif %}" itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
-    {% if street_address is defined %}
+    {% if street_address %}
     <span itemprop="streetAddress">
       {{ street_address.line_1 }}
       {% if street_address.line_2 %}
@@ -42,18 +43,23 @@
       {% endif %}
     </span>
     {% endif %}
-    {% if locality is defined %}
+    {% if locality %}
     <span itemprop="addressLocality">
       {{ locality }}
     </span>
     {% endif %}
-    {% if postcode is defined %}
+    {% if country %}
+    <span itemprop="addressCountry">
+      {{ country }}
+    </span>
+    {% endif %}
+    {% if postcode %}
     <span itemprop="postalCode">
       {{ postcode }}
     </span>
     {% endif %}
   </p>
 {% endif %}
-{% if organisation is defined %}
+{% if organisation %}
 </div>
 {% endif %}

--- a/toolkit/templates/contact-details.html
+++ b/toolkit/templates/contact-details.html
@@ -28,7 +28,8 @@
   {% endif %}
 {% endif %}
 {% if
-  street_address or
+  street_address_line_1 or
+  street_address_line_2 or
   locality or
   country or
   postcode
@@ -36,10 +37,14 @@
   <p class="contact-details-block{% if without_spacing %}-without-spacing{% endif %}" itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
     {% if street_address %}
     <span itemprop="streetAddress">
-      {{ street_address.line_1 }}
-      {% if street_address.line_2 %}
+      {% if street_address_line_1 %}
+        {{ street_address_line_1 }}
+      {% endif %}
+      {% if street_address_line_1 and street_address_line_2 %}
         <br />
-        {{ street_address.line_2 }}
+      {% endif %}
+      {% if street_address_line_2 %}
+        {{ street_address_line_2 }}
       {% endif %}
     </span>
     {% endif %}

--- a/toolkit/templates/contact-details.html
+++ b/toolkit/templates/contact-details.html
@@ -35,10 +35,14 @@
   <p class="contact-details-block{% if without_spacing %}-without-spacing{% endif %}" itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
     {% if street_address is defined %}
     <span itemprop="streetAddress">
-      {{ street_address }}
+      {{ street_address.line_1 }}
+      {% if street_address.line_2 %}
+        <br />
+        {{ street_address.line_2 }}
+      {% endif %}
     </span>
     {% endif %}
-    {% if street_address is defined %}
+    {% if locality is defined %}
     <span itemprop="addressLocality">
       {{ locality }}
     </span>

--- a/toolkit/templates/forms/list-entry.html
+++ b/toolkit/templates/forms/list-entry.html
@@ -1,7 +1,7 @@
 {% if values is not defined %}
   {% set values = [] %}
 {% endif %}
-{% if error is defined %}
+{% if error %}
   <div class="validation-wrapper">
 {% endif %}
   <fieldset class="question {% if first_question %}first-question{% endif %}" id="{{ id }}">
@@ -13,7 +13,7 @@
         {{ hint }}
       </p>
     {% endif %}
-    {% if error is defined %}
+    {% if error %}
       <p class="validation-message" id="error-{{ name }}">
         {{ error }}
       </p>
@@ -29,6 +29,6 @@
       {% endfor %}
     </div>
   </fieldset>
-{% if error is defined %}
+{% if error %}
   </div>
 {% endif %}

--- a/toolkit/templates/forms/selection-buttons.html
+++ b/toolkit/templates/forms/selection-buttons.html
@@ -1,4 +1,4 @@
-{% if error is defined %}
+{% if error %}
   <div class="validation-wrapper">
 {% endif %}
   <fieldset class="question first-question">
@@ -8,7 +8,7 @@
         {{ hint }}
       </p>
     {% endif %}
-    {% if error is defined %}
+    {% if error %}
       <p class="validation-message" id="error-{{ name }}">
         {{ error }}
       </p>
@@ -36,6 +36,6 @@
       {% endfor %}
     {% endif %}
   </fieldset>
-{% if error is defined %}
+{% if error %}
   </div>
 {% endif %}

--- a/toolkit/templates/forms/textbox.html
+++ b/toolkit/templates/forms/textbox.html
@@ -1,4 +1,4 @@
-{% if error is defined %}
+{% if error %}
   <div class="validation-wrapper">
 {% endif %}
   <div class="question">
@@ -10,7 +10,7 @@
         {{ hint }}
       </p>
     {% endif %}
-    {% if error is defined %}
+    {% if error %}
       <p class="validation-message" id="error-{{ name }}">
         {{ error }}
       </p>
@@ -27,6 +27,6 @@
       <input type="text" name="{{ name }}" id="{{ name }}" class="text-box" value="{{ value }}" />
     {% endif %}
   </div>
-{% if error is defined %}
+{% if error %}
   </div>
 {% endif %}


### PR DESCRIPTION
This does two things:
- Check for falseyness of error messages (rather than them being defined explicitly)
- Formalise street address as being two lines

This will make it easier to integrate the templates into the supplier app.