### PR TITLE
Change parameters of option select to match usage

### DIFF
--- a/pages_builder/pages/forms/option-select.yml
+++ b/pages_builder/pages/forms/option-select.yml
@@ -7,52 +7,77 @@ bodyEnd: >
 examples:
   -
     title: With overflowing options
-    name: Market sector
-    id: market_sector
+    label: Market sector
     options:
       -
+        name: market_sector
         id: aerospace
         label: Aerospace
       -
-        id: agriculture-environment-and-natural-resources
+        name: market_sector
+        id: agriculture_environment_and_natural_resources
         label: Agriculture, environment and natural resources
       -
+        name: market_sector
         id: building-and-construction
         label: Building and construction
       -
+        name: market_sector
         id: chemicals
         label: Chemicals
       -
-        id: clothing-footwear-and-fashion
+        name: market_sector
+        id: clothing_footwear_and_fashion
         label: Clothing, footwear and fashion
       -
+        name: market_sector
         id: defence
         label: Defence
       -
-        id: distribution-and-service-industries
+        name: market_sector
+        id: distribution_and_service_industries
         label: Distribution and Service Industries
       -
-        id: electronics-industry
+        name: market_sector
+        id: electronics_industry
         label: Electronics Industry
       -
+        name: market_sector
         id: energy
         label: Energy
       -
+        name: market_sector
         id: engineering
         label: Engineering
 
   -
     title: With a prechecked option, without overflow
-    name: Vegetables
-    id: vegetables
+    label: Vegetables
     options:
       -
+        name: vegetables
         id: carrot
         label: Carrot
         checked: true
       -
+        name: vegetables
         id: potato
         label: Potato
       -
+        name: vegetables
         id: swede
         label: Swede
+  -
+    title: With multiple POST parameters
+    label: Pricing options
+    options:
+      -
+        name: free_tier
+        id: free-option-available
+        label: Free option available
+        value: Free option
+      -
+        name: trial_option
+        id: trial-option-available
+        label: Trial option offereded
+        value: Trial

--- a/pages_builder/pages/forms/option-select.yml
+++ b/pages_builder/pages/forms/option-select.yml
@@ -10,46 +10,55 @@ examples:
     label: Market sector
     options:
       -
-        name: market_sector
+        name: market-sector
         id: aerospace
+        value: aerospace
         label: Aerospace
       -
-        name: market_sector
-        id: agriculture_environment_and_natural_resources
+        name: market-sector
+        id: agriculture-environment-and-natural-resources
+        value: agriculture environment and natural resources
         label: Agriculture, environment and natural resources
       -
-        name: market_sector
+        name: market-sector
         id: building-and-construction
+        value: building and construction
         label: Building and construction
       -
-        name: market_sector
+        name: market-sector
         id: chemicals
+        value: chemicals
         label: Chemicals
       -
-        name: market_sector
-        id: clothing_footwear_and_fashion
+        name: market-sector
+        id: clothing-footwear-and-fashion
+        value: clothing footwear and fashion
         label: Clothing, footwear and fashion
       -
-        name: market_sector
+        name: market-sector
         id: defence
+        value: defence
         label: Defence
       -
-        name: market_sector
-        id: distribution_and_service_industries
+        name: market-sector
+        id: distribution-and-service-industries
+        value: distribution and service industries
         label: Distribution and Service Industries
       -
-        name: market_sector
-        id: electronics_industry
+        name: market-sector
+        id: electronics-industry
+        value: electronics industry
         label: Electronics Industry
       -
-        name: market_sector
+        name: market-sector
         id: energy
+        value: energy
         label: Energy
       -
-        name: market_sector
+        name: market-sector
         id: engineering
         label: Engineering
-
+        value: engineering
   -
     title: With a prechecked option, without overflow
     label: Vegetables
@@ -59,25 +68,28 @@ examples:
         id: carrot
         label: Carrot
         checked: true
+        value: carrot
       -
         name: vegetables
         id: potato
         label: Potato
+        value: potato
       -
         name: vegetables
         id: swede
         label: Swede
+        value: swede
   -
     title: With multiple POST parameters
     label: Pricing options
     options:
       -
-        name: free_tier
+        name: free-tier
         id: free-option-available
         label: Free option available
         value: true
       -
-        name: trial_option
+        name: trial-option
         id: trial-option-available
         label: Trial option offereded
         value: true

--- a/pages_builder/pages/forms/option-select.yml
+++ b/pages_builder/pages/forms/option-select.yml
@@ -75,9 +75,9 @@ examples:
         name: free_tier
         id: free-option-available
         label: Free option available
-        value: Free option
+        value: true
       -
         name: trial_option
         id: trial-option-available
         label: Trial option offereded
-        value: Trial
+        value: true

--- a/toolkit/templates/forms/option-select.html
+++ b/toolkit/templates/forms/option-select.html
@@ -6,7 +6,7 @@
     <div class="js-auto-height-inner">
       {% for option in options %}
         <label for="{{ option.name }}-{{ option.id }}">
-          <input name="{{ option.name }}" value="{{ option.value or option.label }}" id="{{ option.name }}-{{ option.id }}" type="checkbox" aria-controls=""{% if option.checked %} checked="checked"{% endif %}>
+          <input name="{{ option.name }}" value="{{ option.value }}" id="{{ option.name }}-{{ option.id }}" type="checkbox" aria-controls=""{% if option.checked %} checked="checked"{% endif %}>
           {{ option.label }}
         </label>
       {% endfor %}

--- a/toolkit/templates/forms/option-select.html
+++ b/toolkit/templates/forms/option-select.html
@@ -1,12 +1,12 @@
 <div class="govuk-option-select">
   <div class="container-head js-container-head">
-    <div class="option-select-label">{{ name }}</div>
+    <div class="option-select-label">{{ label }}</div>
   </div>
   <div class="options-container">
     <div class="js-auto-height-inner">
       {% for option in options %}
-        <label for="aerospace">
-          <input name="{{id}}" value="{{ option.id }}" id="{{ option.id }}" type="checkbox" aria-controls=""{% if option.checked %} checked="checked"{% endif %}>
+        <label for="{{ option.name }}-{{ option.id }}">
+          <input name="{{ option.name }}" value="{{ option.value or option.label }}" id="{{ option.name }}-{{ option.id }}" type="checkbox" aria-controls=""{% if option.checked %} checked="checked"{% endif %}>
           {{ option.label }}
         </label>
       {% endfor %}


### PR DESCRIPTION
This commit changes the parameters passed to option select to match how it is used in the buyer app. This is a precursor to integrating the toolkit version of option select into the buyer app.

The main change is specifying the `name` parameter for each checkbox individually. This means that multiple 'questions' can now live inside one `option-select`.

This commit also updates the documentation with an example of this usage.

![image](https://cloud.githubusercontent.com/assets/355079/8125015/8cb31534-10d9-11e5-8f68-8176f1c413fc.png)

_Releasing this will be a MAJOR (breaking) change_