### PR TITLE
Fix list entry

### DIFF
--- a/pages_builder/pages/forms/list-entry.yml
+++ b/pages_builder/pages/forms/list-entry.yml
@@ -19,7 +19,7 @@ examples:
       - Three
   -
     question: With an error
-    id: service benefit
+    id: serviceBenefits
     error: Answer required
     number_of_items: 3
-    item_name: feature
+    item_name: benefit

--- a/pages_builder/pages/forms/list-entry.yml
+++ b/pages_builder/pages/forms/list-entry.yml
@@ -9,15 +9,17 @@ bodyEnd: >
 examples:
   -
     question: Service features
-    id: feature
+    id: serviceFeatures
     hint: Include the technical features of your product, eg graphical workflow, remote access. (Maximum 10 words per feature. Maximum 10 features.)
     number_of_items: 10
+    item_name: service feature
     values:
       - One
       - Two
       - Three
   -
     question: With an error
-    id: feature
+    id: service benefit
     error: Answer required
     number_of_items: 3
+    item_name: feature

--- a/toolkit/javascripts/list-entry.js
+++ b/toolkit/javascripts/list-entry.js
@@ -43,15 +43,6 @@
   ListEntry.prototype.addButtonTemplate = Hogan.compile(
     '<button type="button" class="button-secondary list-entry-add">Add another {{listItemName}} ({{entriesLeft}} remaining)</button>'
   );
-  ListEntry.prototype.getIdPattern = function (input) {
-    var pattern = input.id.match(/(p\d+q\d+val)\d+$/);
-
-    if (pattern !== null) {
-      return pattern[1];
-    } else {
-      return false;
-    }
-  };
   ListEntry.prototype.getValues = function () {
     this.entries = [];
     this.$wrapper.find('input').each(function (idx, elm) {

--- a/toolkit/templates/forms/list-entry.html
+++ b/toolkit/templates/forms/list-entry.html
@@ -14,17 +14,17 @@
       </p>
     {% endif %}
     {% if error %}
-      <p class="validation-message" id="error-{{ name }}">
+      <p class="validation-message" id="error-{{ id }}">
         {{ error }}
       </p>
     {% endif %}
-    <div class="input-list" data-list-item-name="feature" id="list-entry-feature">
+    <div class="input-list" data-list-item-name="{{ item_name }}" id="list-entry-{{id}}">
       {% for index in range(1, number_of_items + 1) %}
         <div class="list-entry">
-          <label for="{{id}}-{{index}}" class="text-box-number-label">
-            <span class="visuallyhidden">feature number </span>{{index}}.
+          <label for="{{ id }}-{{ index }}" class="text-box-number-label">
+            <span class="visuallyhidden">{{item_name}} number </span>{{ index }}.
           </label>
-          <input type="text" name="{{id}}" id="{{id}}-{{index}}" class="text-box" value="{{ values[index] }}" />
+          <input type="text" name="{{ id }}" id="{{ id }}-{{ index }}" class="text-box" value="{{ values[index] }}" />
         </div>
       {% endfor %}
     </div>


### PR DESCRIPTION
This commit adjusts how the parameters that are passed into the template are used, especially parameters used to identify elements.

Basically, it makes the `list-entry` pattern work in a real-world use case.

It ensures that:
- the `name` parameter of each textbox matches the key expected by the API
- there is a way of specifying a singular noun for what each item in a list is (eg a feature, a certification)
- there are no clashing IDs, even when the pattern is used multiple times on one page