### PR TITLE
Update look and feel for validation pattern

### DIFF
--- a/pages_builder/pages/forms/textbox.yml
+++ b/pages_builder/pages/forms/textbox.yml
@@ -28,6 +28,12 @@ examples:
     max_length_in_words: 50
   -
     question: Text box with error
-    error: Must be a valid email address
+    error: Answer cannot be more than 50 characters
     name: question-5
+    value: hello2example.com
+  -
+    question: Text box with hint and error
+    hint: eg hello@example.com
+    error: Must be a valid email address
+    name: question-6
     value: hello2example.com

--- a/pages_builder/pages/forms/validation.yml
+++ b/pages_builder/pages/forms/validation.yml
@@ -3,7 +3,6 @@ assetPath: ../govuk_template/assets/
 examples:
   -
     title: Masthead
-    lede: There was a problem with your answer to the following questions
     errors:
       -
         input_name: example-textbox
@@ -12,8 +11,9 @@ examples:
         input_name: example-textbox-2
         question: What street did you grow up on?
   -
-    title: With a custom message
+    title: With a custom message and description
     lede: Something went wrong
+    description: Please make it right
     errors:
       -
         input_name: example-textbox

--- a/toolkit/scss/forms/_hint.scss
+++ b/toolkit/scss/forms/_hint.scss
@@ -2,7 +2,8 @@
 @import "_typography.scss";
 
 .hint {
-  @include copy-19;
+  display: block;
+  @include core-19;
   margin: 0 0 5px 0;
   color: $secondary-text-colour;
 }

--- a/toolkit/scss/forms/_list-entry.scss
+++ b/toolkit/scss/forms/_list-entry.scss
@@ -7,6 +7,7 @@
 
   .list-entry {
     vertical-align: middle;
+    margin-bottom: 15px;
   }
 
   .list-entry-remove {
@@ -23,6 +24,7 @@
   .text-box {
     padding-left: 1.84em;
     width: 100%;
+    margin-bottom: 0;
 
     @include ie-lte(8) {
       width: 95%;

--- a/toolkit/scss/forms/_textboxes.scss
+++ b/toolkit/scss/forms/_textboxes.scss
@@ -4,6 +4,7 @@
 @import "_css3.scss";
 @import "_shims.scss";
 
+%text-box,
 .text-box {
   @include core-19;
   @include box-sizing(border-box);
@@ -18,12 +19,28 @@
   }
 }
 
+%text-box-error {
+  border: 5px solid $red;
+  margin-bottom: 0;
+}
+
+.text-box-with-error {
+  @extend %text-box;
+  @extend %text-box-error;
+}
+
 .text-box-medium {
   height: 6.25em;
 }
 
+%text-box-large,
 .text-box-large {
   height: 10.25em;
+}
+
+.text-box-large-with-error {
+  @extend %text-box-large;
+  @extend %text-box-error;
 }
 
 .text-box-percentage {
@@ -37,4 +54,3 @@
   @include inline-block;
   @include core-19;
 }
-

--- a/toolkit/scss/forms/_validation.scss
+++ b/toolkit/scss/forms/_validation.scss
@@ -40,11 +40,6 @@
     margin: 0;
   }
 
-  .text-box {
-    border: 5px solid $red;
-    margin-bottom: 0;
-  }
-
 }
 
 .validation-message {

--- a/toolkit/scss/forms/_validation.scss
+++ b/toolkit/scss/forms/_validation.scss
@@ -3,8 +3,8 @@
 
 .validation-masthead {
 
-  border: 3px solid $red;
-  padding: 15px 20px 30px 20px;
+  border: 5px solid $red;
+  padding: 15px 15px 20px 15px;
   margin-bottom: 30px;
 
   .validation-masthead-heading {
@@ -13,25 +13,44 @@
     margin-bottom: 15px;
   }
 
+  .validation-masthead-description {
+    @include copy-19;
+    margin-bottom: 5px;
+  }
+
   .validation-masthead-link,
   .validation-masthead-link:link,
   .validation-masthead-link:visited {
     display: block;
     @include core-19;
+    font-weight: bold;
     color: $red;
   }
 
 }
 
 .validation-wrapper {
-  border-left: 3px solid $red;
-  padding: 0 0 5px 20px;
-  margin-bottom: 15px;
+
+  border-left: 5px solid $red;
+  padding: 0 0 5px 15px;
+  margin: 15px 0 30px 0;
   overflow: hidden;
+
+  .question {
+    margin: 0;
+  }
+
+  .text-box {
+    border: 5px solid $red;
+    margin-bottom: 0;
+  }
+
 }
 
 .validation-message {
-  @include copy-19;
+  display: block;
+  @include core-19;
+  font-weight: bold;
   color: $red;
-  margin-bottom: 5px;
+  margin: 5px 0 7px 0;
 }

--- a/toolkit/templates/forms/list-entry.html
+++ b/toolkit/templates/forms/list-entry.html
@@ -5,19 +5,21 @@
   <div class="validation-wrapper">
 {% endif %}
   <fieldset class="question {% if first_question %}first-question{% endif %}" id="{{ id }}">
-    <legend class="question-heading {% if hint is defined %}question-heading-with-hint{% endif %}">
-      {{ question }}
+    <legend>
+      <span class="question-heading {% if hint is defined %}question-heading-with-hint{% endif %}">
+        {{ question }}
+      </span>
+      {% if hint is defined %}
+        <span class="hint">
+          {{ hint }}
+        </span>
+      {% endif %}
+      {% if error %}
+        <span class="validation-message" id="error-{{ id }}">
+          {{ error }}
+        </span>
+      {% endif %}
     </legend>
-    {% if hint is defined %}
-      <p class="hint">
-        {{ hint }}
-      </p>
-    {% endif %}
-    {% if error %}
-      <p class="validation-message" id="error-{{ id }}">
-        {{ error }}
-      </p>
-    {% endif %}
     <div class="input-list" data-list-item-name="{{ item_name }}" id="list-entry-{{id}}">
       {% for index in range(0, number_of_items) %}
         <div class="list-entry">

--- a/toolkit/templates/forms/selection-buttons.html
+++ b/toolkit/templates/forms/selection-buttons.html
@@ -2,19 +2,21 @@
   <div class="validation-wrapper">
 {% endif %}
   <fieldset class="question first-question">
-    {% if hint is defined %}
-    <legend class="question-heading question-heading-with-hint">{{ question }}</legend>
-      <p class="hint">
-        {{ hint }}
-      </p>
-    {% else %}
-    <legend class="question-heading">{{ question }}</legend>
-    {% endif %}
-    {% if error %}
-      <p class="validation-message" id="error-{{ name }}">
-        {{ error }}
-      </p>
-    {% endif %}
+    <legend>
+      <span class="question-heading {% if hint is defined %}question-heading-with-hint{% endif %}">
+          {{ question }}
+      </span>
+      {% if hint is defined %}
+        <span class="hint">
+          {{ hint }}
+        </span>
+      {% endif %}
+      {% if error %}
+        <span class="validation-message" id="error-{{ name }}">
+          {{ error }}
+        </span>
+      {% endif %}
+    </legend>
     {% if type == "boolean" %}
       <label class="selection-button selection-button-boolean" for="{{ name }}-yes">
         Yes

--- a/toolkit/templates/forms/textbox.html
+++ b/toolkit/templates/forms/textbox.html
@@ -20,13 +20,13 @@
     {% if large %}
       {% if max_length_in_words is defined %}
         <div class="word-count">
-          <textarea class="text-box text-box-large" name="{{ name }}" id="{{ name }}" data-max-length-in-words="{{ max_length_in_words }}">{{ value }}</textarea>
+          <textarea class="text-box text-box-large{% if error %}-with-error{% endif %}" name="{{ name }}" id="{{ name }}" data-max-length-in-words="{{ max_length_in_words }}">{{ value }}</textarea>
         </div>
       {% else %}
         <textarea class="text-box text-box-large" name="{{ name }}" id="{{ name }}">{{ value }}</textarea>
       {% endif %}
     {% else %}
-      <input type="text" name="{{ name }}" id="{{ name }}" class="text-box" value="{{ value }}" />
+      <input type="text" name="{{ name }}" id="{{ name }}" class="text-box{% if error %}-with-error{% endif %}" value="{{ value }}" />
     {% endif %}
   </div>
 {% if error %}

--- a/toolkit/templates/forms/textbox.html
+++ b/toolkit/templates/forms/textbox.html
@@ -2,19 +2,21 @@
   <div class="validation-wrapper">
 {% endif %}
   <div class="question">
-    <label for="{{ name }}" class="question-heading{% if hint is defined %}-with-hint{% endif %}">
-      {{ question }}
+    <label for="{{ name }}">
+      <span class="question-heading{% if hint is defined %}-with-hint{% endif %}">
+        {{ question }}
+      </span>
+      {% if hint is defined %}
+        <span class="hint">
+          {{ hint }}
+        </span>
+      {% endif %}
+      {% if error %}
+        <span class="validation-message" id="error-{{ name }}">
+          {{ error }}
+        </span>
+      {% endif %}
     </label>
-    {% if hint is defined %}
-      <p class="hint">
-        {{ hint }}
-      </p>
-    {% endif %}
-    {% if error %}
-      <p class="validation-message" id="error-{{ name }}">
-        {{ error }}
-      </p>
-    {% endif %}
     {% if large %}
       {% if max_length_in_words is defined %}
         <div class="word-count">

--- a/toolkit/templates/forms/validation.html
+++ b/toolkit/templates/forms/validation.html
@@ -2,6 +2,11 @@
   <h3 class="validation-masthead-heading" id="validation-masthead-heading">
     {{ lede or "There was a problem with your answer to the following questions"}}
   </h3>
+  {% if description %}
+    <p class="validation-masthead-description">
+      {{ description }}
+    </p>
+  {% endif %}
   {% for error in errors %}
     <a href="#{{ error.input_name }}" class="validation-masthead-link">{{ error.question }}</a>
   {% endfor %}


### PR DESCRIPTION
This commit is built on top of the work and research that @gemmaleigh did towards
https://github.com/alphagov/govuk_elements/pull/71

It changes two main things:
- the borders and spacing of validation errors
- the nesting of markup to put the error message and hint inside the question's `label` or `legend`

It does not address:
- The language we use in the validation 'masthead', ie just referring users to which questions have errors, rather than explaining why the errors occurred (this is a more comprehensive change that would need to happen across all of our apps)

### Examples
---
![screen shot 2015-06-18 at 16 05 29](https://cloud.githubusercontent.com/assets/355079/8234620/e94c8d70-15d4-11e5-9ef3-8c1dd3ff568c.png)
---
![screen shot 2015-06-18 at 16 05 22](https://cloud.githubusercontent.com/assets/355079/8234631/fe071d3e-15d4-11e5-9ca9-2a51c2ded2db.png)
---
![screen shot 2015-06-18 at 16 06 15](https://cloud.githubusercontent.com/assets/355079/8234622/e9512a88-15d4-11e5-8346-27b6fb04ea78.png)
---
![image](https://cloud.githubusercontent.com/assets/355079/8278692/794781e4-18c5-11e5-9c99-6bbd95c6397c.png)
