### PR TITLE
Add pattern for file upload

### DIFF
--- a/pages_builder/assets/scss/index.scss
+++ b/pages_builder/assets/scss/index.scss
@@ -23,6 +23,7 @@ $path : '../images/';
 @import "forms/_textboxes.scss";
 @import "forms/_validation.scss";
 @import "forms/_word-counter.scss";
+@import "forms/_upload.scss";
 
 
 #wrapper {

--- a/pages_builder/pages/forms/index.yml
+++ b/pages_builder/pages/forms/index.yml
@@ -28,6 +28,9 @@ content: >
         <li>
           <a href="validation.html">Validation</a>
         </li>
+        <li>
+          <a href="upload.html">File upload</a>
+        </li>
       </ul>
     </div>
   </main>

--- a/pages_builder/pages/forms/upload.yml
+++ b/pages_builder/pages/forms/upload.yml
@@ -1,0 +1,20 @@
+pageTitle: File upload
+assetPath: ../govuk_template/assets/
+examples:
+  -
+    question: Please upload a file
+    name: question-1
+  -
+    question: Please replace the file you previously uploaded
+    hint: Hint comprising further information about the question
+    name: question-2
+    value: 1234123412341234-pricing-document.pdf
+  -
+    question: Example of a link to the uploaded file
+    name: question-3
+    link: https://assets.digitalmarketplace.service.gov.uk/documents/654321/1234123412341234-pricing-document.pdf
+    value: Excelsior_CMS-Pricing-2015.pdf
+  -
+    question: With a bad upload
+    name: question-4
+    error: The file you uploaded was too big &ndash; maximum file size is 5Mb

--- a/toolkit/scss/_document.scss
+++ b/toolkit/scss/_document.scss
@@ -33,6 +33,18 @@
 
 }
 
+.document-link-with-narrow-icon {
+
+  @extend %document-link;
+  padding-left: 45px;
+
+  @include ie-lte(8) {
+    padding-left: 35px;
+  }
+
+}
+
+%document-icon,
 .document-icon {
 
   @include bold-16;
@@ -84,6 +96,19 @@
     position: absolute;
     top: 0;
     left: -999em;
+  }
+
+}
+
+.document-icon-blank {
+
+  @extend .document-icon;
+
+  min-width: 8px;
+  min-height: 20px;
+
+  &:before {
+    content: "";
   }
 
 }

--- a/toolkit/scss/forms/_upload.scss
+++ b/toolkit/scss/forms/_upload.scss
@@ -1,0 +1,11 @@
+@import "_typography.scss";
+
+.file-upload-existing-value {
+  @include core-19;
+  margin: 0;
+}
+
+.file-upload-input {
+  @include core-19;
+  margin-top: 5px;
+}

--- a/toolkit/templates/forms/upload.html
+++ b/toolkit/templates/forms/upload.html
@@ -1,0 +1,40 @@
+{% if error %}
+<div class="validation-wrapper">
+{% endif %}
+  <div class="question">
+    <label for="{{ name }}">
+      <span class="question-heading{% if hint is defined %}-with-hint{% endif %}">
+        {{ question }}
+      </span>
+      {% if hint is defined %}
+        <span class="hint">
+          {{ hint }}
+        </span>
+      {% endif %}
+      {% if error %}
+        <span class="validation-message" id="error-{{ name }}">
+          {{ error }}
+        </span>
+      {% endif %}
+    </label>
+    {% if value %}
+      <p class="file-upload-existing-value">
+        {% if link %}
+          <a href="{{ link }}" class='document-link-with-narrow-icon'>
+        {% else %}
+          <span class='document-link-with-narrow-icon'>
+        {% endif %}
+            <span class='document-icon-blank'></span>
+            {{ value }}
+        {% if link %}
+          </a>
+        {% else %}
+          </span>
+        {% endif %}
+      </p>
+    {% endif %}
+    <input type="file" name="{{ name }}" id="{{ name }}" class="file-upload-input" />
+  </div>
+{% if error %}
+</div>
+{% endif %}


### PR DESCRIPTION
This commit adds a template, SASS and documented examples for how to do file uploads.

I know there was some discussion yesterday about linking to uploaded files, so this pattern has that as an option which can be used/not used as you see fit.

![image](https://cloud.githubusercontent.com/assets/355079/8371622/fd72f0ac-1bd1-11e5-8027-7449be23b7f1.png)

![image](https://cloud.githubusercontent.com/assets/355079/8371640/29b78312-1bd2-11e5-8e97-7f09b3e68d3e.png)

![image](https://cloud.githubusercontent.com/assets/355079/8371629/0df8e3d2-1bd2-11e5-9e7b-9cf8772e14ef.png)

![image](https://cloud.githubusercontent.com/assets/355079/8371636/16aabf28-1bd2-11e5-8aed-e6e40fe52445.png)

--

Usage in a template looks like:
``` jinja
{% with 
    question="Please upload a file", 
    name="question-3", 
    value="Excelsior_CMS-Pricing-2015.pdf",
    link="https://assets.digitalmarketplace.service.gov.uk/documents/654321/1234123412341234-pricing-document.pdf", 
    error="File was too big"
%}
    {% include "toolkit/forms/upload.html" %}
{% endwith %}
```