### PR TITLE
Add textboxes for percentages and price

### DIFF
--- a/pages_builder/pages/forms/textbox.yml
+++ b/pages_builder/pages/forms/textbox.yml
@@ -40,17 +40,17 @@ examples:
   -
     question: Numeric textbox with unit before
     name: question-7
-    unit: before
-    unit_symbol: "$"
+    unit: "$"
+    unit_position: before
   -
     question: Numeric textbox with unit after
     name: question-7
-    unit: after
-    unit_symbol: "%"
+    unit: "%"
+    unit_position: after
   -
     question: Numeric textbox with error
     name: question-7
     value: aaaaaa
     error: Price must not contain letters
-    unit: before
-    unit_symbol: "$"
+    unit: "$"
+    unit_position: before

--- a/pages_builder/pages/forms/textbox.yml
+++ b/pages_builder/pages/forms/textbox.yml
@@ -38,19 +38,25 @@ examples:
     name: question-6
     value: hello2example.com
   -
-    question: Numeric textbox with unit before
+    title: Numeric textbox with unit before
+    question: Price
     name: question-7
     unit: "$"
+    unit_in_full: dollars
     unit_position: before
   -
-    question: Numeric textbox with unit after
+    title: Numeric textbox with unit after
+    question: Uptime
     name: question-7
     unit: "%"
+    unit_in_full: percent
     unit_position: after
   -
-    question: Numeric textbox with error
-    name: question-7
+    title: Numeric textbox with error
+    question: Price
+    name: question-8
     value: aaaaaa
     error: Price must not contain letters
     unit: "$"
+    unit_in_full: dollars
     unit_position: before

--- a/pages_builder/pages/forms/textbox.yml
+++ b/pages_builder/pages/forms/textbox.yml
@@ -37,3 +37,20 @@ examples:
     error: Must be a valid email address
     name: question-6
     value: hello2example.com
+  -
+    question: Numeric textbox with unit before
+    name: question-7
+    unit: before
+    unit_symbol: "$"
+  -
+    question: Numeric textbox with unit after
+    name: question-7
+    unit: after
+    unit_symbol: "%"
+  -
+    question: Numeric textbox with error
+    name: question-7
+    value: aaaaaa
+    error: Price must not contain letters
+    unit: before
+    unit_symbol: "$"

--- a/toolkit/scss/forms/_textboxes.scss
+++ b/toolkit/scss/forms/_textboxes.scss
@@ -43,14 +43,50 @@
   @extend %text-box-error;
 }
 
-.text-box-percentage {
+%text-box-with-unit {
+  @extend %text-box;
   @include inline-block;
-  width: 6em;
-  text-align: right;
-  padding-right: 5px;
+  width: 7em;
 }
 
-.text-box-percentage-label {
+%text-box-with-unit-before,
+.text-box-with-unit-before {
+  @extend %text-box-with-unit;
+  margin-left: -40px;
+  padding-left: 30px;
+}
+
+%text-box-with-unit-after,
+.text-box-with-unit-after {
+  @extend %text-box-with-unit;
+  text-align: right;
+  margin-right: -40px;
+  padding-right: 30px;
+}
+
+.text-box-unit {
   @include inline-block;
+  color: $grey-2;
   @include core-19;
+  font-weight: bold;
+  width: 40px;
+  position: relative;
+  z-index: 10;
+  pointer-events: none;
+  text-align: center;
+}
+
+.text-box-with-unit-before-with-error {
+  @extend %text-box-with-unit-before;
+  @extend %text-box-error;
+}
+
+.text-box-with-unit-after-with-error {
+  @extend %text-box-with-unit-after;
+  @extend %text-box-error;
+}
+
+.text-box-unit-qualifier {
+  position: absolute;
+  left: -9999em;
 }

--- a/toolkit/templates/forms/textbox.html
+++ b/toolkit/templates/forms/textbox.html
@@ -5,6 +5,9 @@
     <label for="{{ name }}">
       <span class="question-heading{% if hint is defined %}-with-hint{% endif %}">
         {{ question }}
+        {% if unit_in_full %}
+          <span class="text-box-unit-qualifier">(in {{ unit_in_full }})</span>
+        {% endif %}
       </span>
       {% if hint is defined %}
         <span class="hint">
@@ -28,14 +31,12 @@
     {% else %}
       {% if unit_position == "before" %}
         <label for="{{ name }}" class="text-box-unit">
-          <span class="text-box-unit-qualifier">in </span>
           {{ unit }}
         </label>
       {% endif %}
       <input type="text" name="{{ name }}" id="{{ name }}" class="text-box{% if unit %}-with-unit-{{ unit_position }}{% endif %}{% if error %}-with-error{% endif %}" value="{{ value }}" />
       {% if unit_position == "after" %}
         <label for="{{ name }}" class="text-box-unit">
-          <span class="text-box-unit-qualifier">in </span>
           {{ unit }}
         </label>
       {% endif %}

--- a/toolkit/templates/forms/textbox.html
+++ b/toolkit/templates/forms/textbox.html
@@ -26,17 +26,17 @@
         <textarea class="text-box text-box-large" name="{{ name }}" id="{{ name }}">{{ value }}</textarea>
       {% endif %}
     {% else %}
-      {% if unit == "before" %}
+      {% if unit_position == "before" %}
         <label for="{{ name }}" class="text-box-unit">
           <span class="text-box-unit-qualifier">in </span>
-          {{ unit_symbol }}
+          {{ unit }}
         </label>
       {% endif %}
-      <input type="text" name="{{ name }}" id="{{ name }}" class="text-box{% if unit %}-with-unit-{{unit}}{% endif %}{% if error %}-with-error{% endif %}" value="{{ value }}" />
-      {% if unit == "after" %}
+      <input type="text" name="{{ name }}" id="{{ name }}" class="text-box{% if unit %}-with-unit-{{ unit_position }}{% endif %}{% if error %}-with-error{% endif %}" value="{{ value }}" />
+      {% if unit_position == "after" %}
         <label for="{{ name }}" class="text-box-unit">
           <span class="text-box-unit-qualifier">in </span>
-          {{ unit_symbol }}
+          {{ unit }}
         </label>
       {% endif %}
     {% endif %}

--- a/toolkit/templates/forms/textbox.html
+++ b/toolkit/templates/forms/textbox.html
@@ -26,7 +26,19 @@
         <textarea class="text-box text-box-large" name="{{ name }}" id="{{ name }}">{{ value }}</textarea>
       {% endif %}
     {% else %}
-      <input type="text" name="{{ name }}" id="{{ name }}" class="text-box{% if error %}-with-error{% endif %}" value="{{ value }}" />
+      {% if unit == "before" %}
+        <label for="{{ name }}" class="text-box-unit">
+          <span class="text-box-unit-qualifier">in </span>
+          {{ unit_symbol }}
+        </label>
+      {% endif %}
+      <input type="text" name="{{ name }}" id="{{ name }}" class="text-box{% if unit %}-with-unit-{{unit}}{% endif %}{% if error %}-with-error{% endif %}" value="{{ value }}" />
+      {% if unit == "after" %}
+        <label for="{{ name }}" class="text-box-unit">
+          <span class="text-box-unit-qualifier">in </span>
+          {{ unit_symbol }}
+        </label>
+      {% endif %}
     {% endif %}
   </div>
 {% if error %}


### PR DESCRIPTION
This commit adds two new patterns which will be useful in the SSP. The percentage one doesn't exactly match what was in the previous SSP (it had the '%' outset and in black), but it's more consistent to have it inset and in grey.

**A textbox with the unit after, eg for entering a percentage**

![screen shot 2015-06-30 at 07 48 18](https://cloud.githubusercontent.com/assets/355079/8425392/2a8d37fe-1efd-11e5-97d4-037efcad37ee.png)

--

**A textbox with the unit before, eg for entering a price**

![screen shot 2015-06-30 at 07 48 07](https://cloud.githubusercontent.com/assets/355079/8425390/2709afae-1efd-11e5-82b5-890f3711b666.png)

--

![image](https://cloud.githubusercontent.com/assets/355079/8425464/f8234fe6-1efd-11e5-9fe6-b2cbac91e26f.png)