### PR TITLE
Align validation wrapper with question/input

### DIFF
--- a/toolkit/scss/forms/_validation.scss
+++ b/toolkit/scss/forms/_validation.scss
@@ -32,12 +32,17 @@
 .validation-wrapper {
 
   border-left: 5px solid $red;
-  padding: 0 0 5px 15px;
+  padding: 0 0 0 15px;
   margin: 15px 0 30px 0;
   overflow: hidden;
 
   .question {
     margin: 0;
+  }
+
+  .question-heading,
+  .question-heading-with-hint {
+    padding-top: 0;
   }
 
 }


### PR DESCRIPTION
Removes some superfluous spacing (cc @ralph-hawkins)

Before | After
--- | ---
![image](https://cloud.githubusercontent.com/assets/355079/8455391/2d657be4-1ffc-11e5-8407-ec630ea4bdc0.png) | ![image](https://cloud.githubusercontent.com/assets/355079/8455397/3a178c2e-1ffc-11e5-9af7-04885bbe4d6a.png)
