### PR TITLE
Draw custom underlines for links in browse-list

### DIFF
--- a/pages_builder/assets/scss/index-ie9.scss
+++ b/pages_builder/assets/scss/index-ie9.scss
@@ -1,0 +1,7 @@
+// BASE STYLESHEET FOR IE 9 COMPILER
+
+$is-ie: true;
+$ie-version: 9;
+$mobile-ie6: false;
+
+@import "index.scss";

--- a/pages_builder/pages/browse-list.yml
+++ b/pages_builder/pages/browse-list.yml
@@ -5,16 +5,22 @@ examples:
     items:
       -
         title: Find cloud technology and support
-        link: '#'
+        link: 'https://www.gov.uk'
         body: eg web hosting or IT health checks
-        subtext: 'Procurement framework: G-Cloud'
+        subtext: 'Procurement framework: <a href="#">G-Cloud</a>'
       -
-        title: Find specialists to work on digital projects
-        link: '#'
+        title: Find specialists to work on digital projects to work on digital projects to work on digital projects to work on digital projects
+        link: '#nope'
         body: eg web hosting or IT health checks
-        subtext: 'Procurement framework: Digital Services'
+        subtext: 'Procurement framework: <a href="#">Digital Services</a>'
       -
         title: Software as a Service
-        link: '#'
+        link: '#nope'
         body: 'Find applications or services that are run over the internet or in the cloud'
         subtext: eg accounting, email
+  -
+    items:
+      -
+        title: Apply to G-Cloud 10
+        link: '#nope'
+        body: G-Cloud 10 is open for applications until 1 October 2019

--- a/toolkit/scss/_browse_list.scss
+++ b/toolkit/scss/_browse_list.scss
@@ -2,6 +2,7 @@
 @import "_typography.scss";
 @import "_measurements.scss";
 @import "_shims.scss";
+@import "_conditionals.scss";
 
 .browse-list {
   padding: 0;
@@ -12,20 +13,41 @@
   margin-bottom: $gutter;
 }
 
-.browse-list-item-link {
-  @include inline-block;
-  @include heading-27;
+.browse-list-item-link,
+a.browse-list-item-link {
+
+  display: inline;
+  @include heading-24;
   font-weight: bold;
   text-decoration: none;
+  @include ie-lte(9) {
+    text-decoration: underline;
+  }
+  box-shadow: inset 0 -11px 0 0 $white, inset 0 -12px 0 0; // 1px underline, same
+                                                            // colour as text
+
+  &:visited {
+    color: $link-visited-colour;
+  }
+
+  &:hover {
+    color: $link-hover-colour;
+  }
+
+  &:active,
+  &:focus {
+    box-shadow: inset 0 -11px 0 0 $yellow, inset 0 -11px 0 0, inset 0 -12px 0 0, inset 0 0 0 2em $yellow;
+  }
+
 }
 
 .browse-list-item-body {
-  margin: 0;
-  @include copy-19;
+  margin: 5px 0 0 0;
+  @include core-16;
 }
 
 .browse-list-item-subtext {
   margin: 0;
-  @include core-14;
+  @include copy-16;
   color: $secondary-text-colour;
 }

--- a/toolkit/scss/_browse_list.scss
+++ b/toolkit/scss/_browse_list.scss
@@ -20,11 +20,26 @@ a.browse-list-item-link {
   @include heading-24;
   font-weight: bold;
   text-decoration: none;
+  border-bottom: 1px solid;
+  position: relative;
+  top: -12px;
+
   @include ie-lte(9) {
     text-decoration: underline;
+    border-bottom: none;
+    top: 0;
   }
-  box-shadow: inset 0 -11px 0 0 $white, inset 0 -12px 0 0; // 1px underline, same
-                                                            // colour as text
+
+  span {
+
+    position: relative;
+    top: 12px;
+
+    @include ie-lte(9) {
+      top: 0;
+    }
+
+  }
 
   &:visited {
     color: $link-visited-colour;
@@ -36,7 +51,27 @@ a.browse-list-item-link {
 
   &:active,
   &:focus {
-    box-shadow: inset 0 -11px 0 0 $yellow, inset 0 -11px 0 0, inset 0 -12px 0 0, inset 0 0 0 2em $yellow;
+
+    outline: none;
+    background: none;
+
+    @include ie-lte(9) {
+      background: $yellow;
+      outline: 3px solid $yellow;
+    }
+
+    span {
+
+      background: $yellow;
+      outline: 3px solid $yellow;
+
+      @include ie-lte(9) {
+        background: none;
+        outline: none;
+      }
+
+    }
+
   }
 
 }

--- a/toolkit/scss/_browse_list.scss
+++ b/toolkit/scss/_browse_list.scss
@@ -20,7 +20,7 @@ a.browse-list-item-link {
   @include heading-24;
   font-weight: bold;
   text-decoration: none;
-  border-bottom: 1px solid;
+  border-bottom: 1px solid; // No border colour, is inherited from text colour
   position: relative;
   top: -12px;
 

--- a/toolkit/templates/browse-list.html
+++ b/toolkit/templates/browse-list.html
@@ -1,7 +1,7 @@
 <ul class="browse-list">
   {% for item in items %}
     <li class="browse-list-item">
-      <a class="browse-list-item-link" href="{{ item.link }}">{{ item.title }}</a>
+      <a class="browse-list-item-link" href="{{ item.link }}"><span>{{ item.title }}</span></a>
       <p class="browse-list-item-body">
         {{ item.body }}
       </p>


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/355079/8572435/7f1b7712-2584-11e5-8959-b56a9deecd04.png)

--

We have noticed in user research and from feedback that support has received that it is not always obvious that these are links.

Adding an underline to these links should help, but the default underlines on large text are heavy and make the text less legible (or that's what we intuit anyway).

The GOV.UK template uses a CSS `border` for drawing a nice, 1px underline on the GOV.UK logo when hovered. So there is a visual precedent.

Using borders doesn't usually work so well on text, because they sit a lot lower than the normal position of an underline. ~~Using box-shadow instead allows control of the vertical position of the underline, as well as the thickness (thickness is managed by drawing two shadows, one for the blue and a white one to mask it).~~  This can be worked around with a  `<span>` nested inside the link in order to relatively position
the text at a vertical offset from the bottom border.

--

![image](https://cloud.githubusercontent.com/assets/355079/8571629/e6759442-257f-11e5-8d23-a07f178db301.png)
<sub>Latest Chrome, OS X Yosemite</sub>

--

![image](https://cloud.githubusercontent.com/assets/355079/8571847/df7edc56-2580-11e5-82be-cce469c18546.png)
<sub>Samsung Galaxy S4, Android 4.4</sub>

--

For older browsers we fall back to a normal `text-decoration: underline` (IE9 and below) or no underline (_really_ old non-IE browsers that don't support box-shadow).

![image](https://cloud.githubusercontent.com/assets/355079/8571712/49ad4ffa-2580-11e5-931c-5dd537c031f7.png)
<sub>IE 8, Windows XP</sub>

![image](https://cloud.githubusercontent.com/assets/355079/8571774/8a66f32a-2580-11e5-9741-b0c760c43c98.png)
<sub>Firefox 3.6, Windows XP</sub>

-- 

This pull request also makes slight changes to the spacing and type size of the text underneath the links.