### PR TITLE
Don't escape HTML in places where HTML may be used

### DIFF
--- a/toolkit/templates/beta-banner.html
+++ b/toolkit/templates/beta-banner.html
@@ -1,5 +1,5 @@
 <div class="phase-banner phase-banner-beta">
   <p>
-    <strong class="phase-tag">BETA</strong> {{ message }}
+    <strong class="phase-tag">BETA</strong> {{ message|safe }}
   </p>
 </div>

--- a/toolkit/templates/browse-list.html
+++ b/toolkit/templates/browse-list.html
@@ -6,7 +6,7 @@
         {{ item.body }}
       </p>
       <p class="browse-list-item-subtext">
-        {{ item.subtext }}
+        {{ item.subtext|safe }}
       </p>
     </li>
   {% endfor %}

--- a/toolkit/templates/notification-banner.html
+++ b/toolkit/templates/notification-banner.html
@@ -1,6 +1,6 @@
 <div class="banner-{{ type }}{% if action is defined %}-with-action{% else %}-without-action{% endif %}">
   <p class="banner-message">
-    {{ message }}
+    {{ message|safe }}
   </p>
   {{ action }}
 </div>

--- a/toolkit/templates/search-results.html
+++ b/toolkit/templates/search-results.html
@@ -7,7 +7,7 @@
       {{ result.supplier }}
     </p>
     <p class="search-result-excerpt">
-      {{ result.excerpt }}
+      {{ result.excerpt|safe }}
     </p>
     <ul class="search-result-metadata">
       {% for item in result.metadata %}

--- a/toolkit/templates/search-summary.html
+++ b/toolkit/templates/search-summary.html
@@ -1,3 +1,3 @@
 <p class="search-summary">
-  {{ content }}
+  {{ content|safe }}
 </p>


### PR DESCRIPTION
There are a number of patterns which only work when passed HTML in their parameters.

This commit modifies those occurrences, and only those occurences, to not escape HTML when given.