### PR TITLE
Improve code snippets and documentation

### DIFF
--- a/pages_builder/assets/javascripts/onready.js
+++ b/pages_builder/assets/javascripts/onready.js
@@ -26,4 +26,9 @@
       filters[0].open();
     }
   }
+
+  $('.code').removeClass("open").click(function() {
+      $(this).toggleClass('open');
+  });
+
 })(window);

--- a/pages_builder/assets/scss/index.scss
+++ b/pages_builder/assets/scss/index.scss
@@ -33,18 +33,64 @@ $path : '../images/';
 
 .code {
 
-  box-shadow: inset 0 0 50px 0 rgba(50, 20, 0, .025);
-  background: rgb(250, 250, 250);
+  $code-background: rgb(250, 250, 250);
+  $code-keyline: rgb(230, 230, 230);
+
+  background: rgb(245, 245, 245);
+  background-image: linear-gradient(
+      0deg,
+      $code-background 0,
+      $code-background 1.2em,
+      $code-keyline 1.2em,
+      $code-keyline 1.25em
+    );
+  background-size: 1.25em 1.25em;
+  background-position: 0 10px;
+  box-shadow: inset 0 0 0 1px $code-keyline, inset 0 3em 0 0 $code-background;
   padding: 10px 10px 15px 15px;
   font-family: monospace;
   font-size: 17px;
   margin-bottom: 30px;
-  color: #888;
+  color: $grey-1;
   position: relative;
-  overflow: scroll;
+  max-height: 1em;
+  overflow: hidden;
+  cursor: pointer;
+
+  &:before {
+    content: "\25b6";
+    color: rgba($grey-1, 0.5);
+  }
 
   &:hover {
-    color: #111;
+
+    &:before {
+      color: $grey-1;
+    }
+
+  }
+
+  .highlight {
+    display: none;
+    overflow: scroll;
+    background: transparent !important;
+  }
+
+  &.open {
+
+    cursor: default;
+    max-height: none;
+    padding-bottom: 5px;
+
+    &:before {
+      content: "\25bc";
+      cursor: pointer;
+    }
+
+    .highlight {
+      display: block;
+    }
+
   }
 
 }
@@ -54,10 +100,10 @@ $path : '../images/';
   position: absolute;
   top: 0;
   right: 0;
-  margin: 10px 10px 0 0;
+  margin: 5px 10px 0 0;
   z-index: 100;
   color: rgba(0, 0, 0, 0.3);
-  font-weight: bold;
+  font-weight: normal;
 }
 
 

--- a/pages_builder/generate_pages.py
+++ b/pages_builder/generate_pages.py
@@ -11,7 +11,7 @@ from template_handler import TemplateHandler
 from asset_compiler import AssetCompiler
 from jinja2 import Template
 from pygments import highlight
-from pygments.lexers import HtmlLexer, JavascriptLexer
+from pygments.lexers import HtmlLexer, DjangoLexer
 from pygments.formatters import HtmlFormatter
 
 
@@ -104,6 +104,10 @@ class Styleguide_publisher(object):
                     template_subfolder.strip("/"),
                     template_name + ".html"
                 )
+                parameters_template_file = os.path.join(
+                    self.repo_root,
+                    "pages_builder/parameters_template.html"
+                )
                 if (os.path.isfile(template_file)):
                     template = Template(open(template_file, "r").read())
                 else:
@@ -114,9 +118,20 @@ class Styleguide_publisher(object):
                         # title is a parameter reserved for naming the pattern
                         # in the documentation
                         parameters.pop("title", None)
+                    print("==========x=x=x=x=x=x=x====")
+                    print(parameters)
+                    parameters_template = Template(
+                        open(parameters_template_file).read()
+                    )
+                    rendered_parameters = parameters_template.render(
+                        {
+                            "parameters": parameters,
+                            "file": template_subfolder.strip("/") + "/" + template_name
+                        }
+                    )
                     partial["examples"][index]["parameters"] = highlight(
-                        json.dumps(parameters, indent=4),
-                        JavascriptLexer(),
+                        rendered_parameters,
+                        DjangoLexer(),
                         HtmlFormatter(noclasses=True)
                     )
                     rendered_markup = template.render(
@@ -150,8 +165,8 @@ class Styleguide_publisher(object):
                                 {{#examples}}
                                     {{#title}}<h2>{{title}}</h2>{{/title}}
                                     {{{markup}}}
-                                    <div class="code open"><h3 class="code-label">Template ({{ templateFile }})</h3>{{{highlighted_markup}}}</div>
-                                    <div class="code open"><h3 class="code-label">Parameters</h3>{{{parameters}}}</div>
+                                    <div class="code open"><h3 class="code-label">HTML</h3>{{{highlighted_markup}}}</div>
+                                    <div class="code open"><h3 class="code-label">Jinja</h3>{{{parameters}}}</div>
                                 {{/examples}}
                             </div>
                         </main>

--- a/pages_builder/generate_pages.py
+++ b/pages_builder/generate_pages.py
@@ -118,8 +118,6 @@ class Styleguide_publisher(object):
                         # title is a parameter reserved for naming the pattern
                         # in the documentation
                         parameters.pop("title", None)
-                    print("==========x=x=x=x=x=x=x====")
-                    print(parameters)
                     parameters_template = Template(
                         open(parameters_template_file).read()
                     )
@@ -165,8 +163,8 @@ class Styleguide_publisher(object):
                                 {{#examples}}
                                     {{#title}}<h2>{{title}}</h2>{{/title}}
                                     {{{markup}}}
-                                    <div class="code open"><h3 class="code-label">HTML</h3>{{{highlighted_markup}}}</div>
-                                    <div class="code open"><h3 class="code-label">Jinja</h3>{{{parameters}}}</div>
+                                    <div class="code open" data-lang="html"><h3 class="code-label">HTML</h3>{{{highlighted_markup}}}</div>
+                                    <div class="code open" data-lang="jinja"><h3 class="code-label">Jinja</h3>{{{parameters}}}</div>
                                 {{/examples}}
                             </div>
                         </main>

--- a/pages_builder/parameters_template.html
+++ b/pages_builder/parameters_template.html
@@ -1,0 +1,9 @@
+{{ '
+{%
+  with' }}
+{%- for key, value in parameters.iteritems() %}
+  {{ key }} = "{{ value }}",
+{%- endfor %}
+{{ '%}' }}
+  {{ '{% include "toolkit/templates/' }}{{ file }}{{ '.html" %}' }}
+{{ '{% endwith %}' }}


### PR DESCRIPTION
This pull request:
- Renders the template parameters as Jinja not JSON, to enable _cut and paste based development™_
- Makes the code examples collapsible so that it's easier to scan through the examples themselves (will think in the future about using a cookie to keep them open/closed on a per-user basis

![image](https://cloud.githubusercontent.com/assets/355079/8673410/32e760f0-2a2e-11e5-9916-749a80ff62c7.png)

