### PR TITLE
Tweak spacing on browse list

### DIFF
--- a/pages_builder/pages/browse-list.yml
+++ b/pages_builder/pages/browse-list.yml
@@ -11,7 +11,6 @@ examples:
       -
         title: Find specialists to work on digital projects to work on digital projects to work on digital projects to work on digital projects
         link: '#nope'
-        body: eg web hosting or IT health checks
         subtext: 'Procurement framework: <a href="#">Digital Services</a>'
       -
         title: Software as a Service

--- a/toolkit/scss/_browse_list.scss
+++ b/toolkit/scss/_browse_list.scss
@@ -77,12 +77,12 @@ a.browse-list-item-link {
 }
 
 .browse-list-item-body {
-  margin: 5px 0 0 0;
+  margin: 5px 0 5px 0;
   @include core-16;
 }
 
 .browse-list-item-subtext {
   margin: 0;
-  @include copy-16;
+  @include core-16;
   color: $secondary-text-colour;
 }


### PR DESCRIPTION
cc/ @ralph-hawkins 

Better visual grouping of items that don't have a body.

Before 
--
![link-spacing-before](https://cloud.githubusercontent.com/assets/355079/8702601/9b313540-2b10-11e5-8330-19ea8e7a3f33.png)

After
--
![link-spacing-after](https://cloud.githubusercontent.com/assets/355079/8702602/9b33a85c-2b10-11e5-9d7c-b82cd17c239b.png)

Difference
--
![link-spacing-difference](https://cloud.githubusercontent.com/assets/355079/8702603/9b344bd6-2b10-11e5-9bae-74dd7f477453.png)