### PR TITLE
Refactor summary pattern

### DIFF
--- a/pages_builder/pages/forms/summary.yml
+++ b/pages_builder/pages/forms/summary.yml
@@ -5,51 +5,98 @@ examples:
     heading: Summary item with no entries
     empty_message: You haven't submitted any services yet
   -
-    heading: Summary item
+    heading: Summary item with column headings
+    field_headings:
+      - Name
+      - Content
+    field_headings_visible: True
     rows:
       -
-        name: Summary item name
-        content: Summary item content
-        action: '<a href="#">Change<span class="visuallyhidden"> Summary item</span></a>'
+        fields:
+          - Summary item name
+          - Summary item content
+      -
+        fields:
+          - Summary item name
+          - Summary item content
+      -
+        fields:
+          - Summary item name
+          - Summary item content
+      -
+        fields:
+          - Summary item name
+          - Summary item content
   -
-    heading: Summary item with action
-    edit_link: "#"
+    heading: Summary item with many columns
+    field_headings:
+      - Name
+      - ID
+      - Framework
+      - Lot
+      - Last edited
+      - Action
+    field_headings_visible: True
+    with_action_field: True
     rows:
       -
-        name: Summary item name
-        content: Summary item content
-        action: '<a href="#">Change<span class="visuallyhidden"> Summary item</span></a>'
+        fields:
+          - <a href="#">Excelsior CMS</a>
+          - 1234 5678 9012 3456
+          - G-Cloud 5
+          - SaaS
+          - 12 June 2015
+          - <a href="#">Edit</a>
+  -
+    heading: Summary item with wide first column
+    wide_first_column: True
+    rows:
+      -
+        fields:
+          - User access control within management interfaces
+          - Yes
+  -
+    heading: Summary item with top-level action
+    top_link: "#"
+    top_link_label: Add new service
+    rows:
+      -
+        fields:
+          - Summary item name
+          - Summary item content
   -
     heading: Summary item with number
     index: 1
+    with_action_field: True
     rows:
       -
-        name: Summary item name
-        content: Summary item content
-        action: '<a href="#">Change<span class="visuallyhidden"> Summary item</span></a>'
+        fields:
+          - Summary item name
+          - Summary item content
+          - '<a href="#">Change<span class="visuallyhidden"> Summary item</span></a>'
   -
     heading: Summary item with name field as link
+    with_action_field: True
     rows:
       -
-        name: <a href="#">Summary item name</a>
-        content: Summary item content
-        action: '<a href="#">Change<span class="visuallyhidden"> Summary item</span></a>'
+        fields:
+          - <a href="#">Summary item name</a>
+          - Summary item content
+          - '<a href="#">Change<span class="visuallyhidden"> Summary item</span></a>'
   -
     heading: Summary item with content field as list
     rows:
       -
-        name: Summary item name
-        content: >
-          <ul>
-            <li>Summary item content 1</li>
-            <li>Summary item content 2</li>
-          </ul>
-        action: '<a href="#">Change<span class="visuallyhidden"> Summary item</span></a>'
+        fields:
+          - Summary item name
+          - <ul><li>Summary item content 1</li><li>Summary item content 2</li></ul>
   -
     heading: Summary item with incomplete entry
+    top_link: "#"
+    top_link_label: Edit <span class="visuallyhidden">summary item with incomplete entry</span>
     rows:
       -
         incomplete: true
-        name: Summary item name
-        content: Summary item content
-        action: '<a href="#">Change<span class="visuallyhidden"> Summary item</span></a>'
+        fields:
+          - Summary item name
+          - '<a href="#">Summary item content</a>'

--- a/toolkit/scss/forms/_summary.scss
+++ b/toolkit/scss/forms/_summary.scss
@@ -33,10 +33,22 @@
   padding-left: 75%;
   position: relative;
   z-index: 10;
+  font-weight: bold;
 
   @include ie(6) {
     zoom: 1;
   }
+}
+
+.summary-item-no-content {
+  color: $secondary-text-colour;
+  @include core-16;
+  margin: 0 0 15px 0;
+  border-top: 1px solid $grey-3;
+  border-bottom: 1px solid $grey-3;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  max-width: 100%;
 }
 
 %summary-item-body {
@@ -45,59 +57,62 @@
   border-bottom: 1px solid $grey-3;
 }
 
-p.summary-item-body {
-  @extend %summary-item-body;
-  @include core-19;
-  border-top: 1px solid $grey-3;
-  padding-top: 10px;
-  padding-bottom: 10px;
-  max-width: 100%;
-}
-
-%summary-item-row {
+%summary-item-row,
+.summary-item-row {
   @include core-19;
   text-align: right;
   border-top: 1px solid $grey-3;
 }
 
 table.summary-item-body {
+
   @extend %summary-item-body;
   border-collapse: collapse;
   border-spacing: 0;
 
-  thead tr {
-    position: absolute;
-    left: -9999em;
-  }
-
   tbody {
-    .summary-item-row {
-      @extend %summary-item-row;
-    }
 
     td {
       padding-top: 10px;
       padding-bottom: 10px;
       vertical-align: top;
     }
+
   }
+
 }
 
-%summary-item-field {
+%summary-item-field,
+.summary-item-field {
+
   vertical-align: middle;
   text-align: left;
+  @include core-16;
+  padding-left: 25px;
+
+  ul {
+    margin: 0;
+    list-style-type: disc;
+    padding: 0 0 0 20px;
+  }
+
 }
 
-%summary-item-field-name,
-.summary-item-field-name {
+.summary-item-field-first {
   @extend %summary-item-field;
   width: 33.333%;
-  padding-right: 25px;
+  padding-left: 0;
 }
 
-.summary-item-field-name-wider {
-  @extend %summary-item-field-name;
+.summary-item-field-first-wider {
+  @extend %summary-item-field;
   width: 50%;
+  padding-left: 0;
+}
+
+.summary-item-field-with-action {
+  @extend %summary-item-field;
+  text-align: right;
 }
 
 .summary-item-field-headings {
@@ -109,27 +124,38 @@ table.summary-item-body {
 
 }
 
-.summary-item-field-content {
-  @extend %summary-item-field;
-  width: 66.666%;
-  padding-left: 25px;
-
-  ul {
-    margin: 0;
-    list-style-type: disc;
-    padding: 0 0 0 20px;
-  }
+.summary-item-field-headings-visible {
+  @include core-16;
+  font-weight: bold;
+  text-align: left;
+  border-top: 1px solid $grey-3;
 }
 
-.summary-item-field-action {
-  @extend %summary-item-field;
-  padding-left: 20px;
+%summary-item-field-heading,
+.summary-item-field-heading {
+  padding: 10px 0 10px 25px;
+}
+
+.summary-item-field-heading-first {
+  @extend %summary-item-column-heading;
+  padding-left: 0;
 }
 
 .summary-item-row-incomplete {
+
   @extend %summary-item-row;
 
-  .summary-item-field-name {
+  .summary-item-field {
+
+    color: $accessible-orange;
+
+    a {
+      color: $accessible-orange;
+    }
+
+  }
+
+  .summary-item-field-first {
 
     span {
       padding-left: 10px;
@@ -138,10 +164,4 @@ table.summary-item-body {
 
   }
 
-  .summary-item-field-content {
-    color: $accessible-orange;
-    a {
-      color: $accessible-orange;
-    }
-  }
 }

--- a/toolkit/scss/forms/_summary.scss
+++ b/toolkit/scss/forms/_summary.scss
@@ -6,8 +6,7 @@
 
 .summary-item-heading,
 %summary-item-heading {
-  @include core-24;
-  font-weight: bold;
+  @include bold-24;
   position: relative;
   padding: 35px 25% 0 0;
   margin: 0 0 10px 0;
@@ -125,8 +124,7 @@ table.summary-item-body {
 }
 
 .summary-item-field-headings-visible {
-  @include core-16;
-  font-weight: bold;
+  @include bold-16;
   text-align: left;
   border-top: 1px solid $grey-3;
 }

--- a/toolkit/templates/forms/summary.html
+++ b/toolkit/templates/forms/summary.html
@@ -1,46 +1,39 @@
 <h2 class="summary-item-heading">
-    {% if index is defined %}
+    {% if index %}
       <span class="summary-item-heading-number">{{ index }}.</span>
     {% endif %}
     {{ heading }}
 </h2>
-{% if edit_link is defined %}
+{% if top_link %}
   <p class="summary-item-top-level-action">
-    <a href="{{ edit_link }}" class="summary-change-link">Edit <span class="visuallyhidden"> {{ heading }}</span></a>
+    <a href="{{ top_link }}" class="summary-change-link">{{ top_link_label }}</a>
   </p>
 {% endif %}
-{% if rows is defined %}
+{% if rows %}
   <table class="summary-item-body">
-    <thead class="summary-item-field-headings">
+    <thead class="summary-item-field-headings{% if field_headings_visible %}-visible{% endif %}">
       <tr>
-        <th scope="col">
-          Name
-        </th>
-        <th scope="col">
-          Content
-        </th>
+        {% for field_heading in field_headings %}
+          <th scope="col" class="summary-item-field-heading{% if loop.first %}-first{% endif %}">
+            {{ field_heading }}
+          </th>
+        {% endfor %}
       </tr>
     </thead>
     <tbody>
       {% for row in rows %}
         <tr class="summary-item-row{% if row.incomplete %}-incomplete{% endif %}">
-          <td class="summary-item-field-name">
-            <span>{{ row.name }}</span>
-          </td>
-          <td class="summary-item-field-content">
-            {{ row.content }}
-          </td>
-          {% if row.action %}
-            <td class="summary-item-action-field">
-              {{ row.action }}
+          {% for field in row.fields %}
+            <td class="summary-item-field{% if loop.first %}-first{% endif %}{% if loop.first and wide_first_column %}-wider{% endif %}{% if loop.last and with_action_field %}-with-action{% endif %}">
+              <span>{{ field }}</span>
             </td>
-          {% endif %}
+          {% endfor %}
         </tr>
       {% endfor %}
     </tbody>
   </table>
 {% else %}
-  <p class="hint summary-item-no-content">
+  <p class="summary-item-no-content">
     {{ empty_message }}
   </p>
 {% endif %}


### PR DESCRIPTION
This commit makes it possible to:
- have arbitrary numbers of columns
- specify whether column headings should be shown (and styled) or hidden
- use the template, rather than having to copy/paste the markup

It also alters some type sizes and weights to better match the GOV.UK pattern and make the top-level links more obvious.

Full documentation
--
![summary - digital marketplace frontend toolkit](https://cloud.githubusercontent.com/assets/355079/8728348/83855ff8-2bdc-11e5-8d09-256e568c322f.png)

Jinja code for the last example
--
``` Jinja
{%
  with
  rows = [
    {
        "fields": [
            "Summary item name", 
            "<a href=\"#\">Summary item content</a>"
        ], 
        "incomplete": true
    }
  ],
  top_link = "#",
  heading = "Summary item with incomplete entry",
  top_link_label = "Edit <span class=\"visuallyhidden\">summary item with incomplete entry</span>"
%}
  {% include "toolkit/templates/forms/summary.html" %}
{% endwith %}
```