### PR TITLE
Allow HTML to be passed to summary table cells

### DIFF
--- a/toolkit/templates/forms/summary.html
+++ b/toolkit/templates/forms/summary.html
@@ -25,7 +25,7 @@
         <tr class="summary-item-row{% if row.incomplete %}-incomplete{% endif %}">
           {% for field in row.fields %}
             <td class="summary-item-field{% if loop.first %}-first{% endif %}{% if loop.first and wide_first_column %}-wider{% endif %}{% if loop.last and with_action_field %}-with-action{% endif %}">
-              <span>{{ field }}</span>
+              <span>{{ field|safe }}</span>
             </td>
           {% endfor %}
         </tr>


### PR DESCRIPTION
Table cells can contain things like:
- lists
- [links](#)

…and we've decided that the prefered way to do this is build the HTML in the app and pass it through to the toolkit, like we do with the beta banner, etc.

The alternative would be to have the pattern know about things like assurance approaches, which would make our toolkit very tightly coupled to our current, limited set of data structures.