### PR TITLE
Pass HTML to table summary headings, make table heading optional.

### DIFF
--- a/pages_builder/assets/javascripts/onready.js
+++ b/pages_builder/assets/javascripts/onready.js
@@ -27,8 +27,8 @@
     }
   }
 
-  $('.code').removeClass("open").click(function() {
-      $(this).toggleClass('open');
+  $('.code').removeClass("open").find('.code-label').click(function() {
+      $(this).parent().toggleClass('open');
   });
 
 })(window);

--- a/pages_builder/assets/scss/index.scss
+++ b/pages_builder/assets/scss/index.scss
@@ -97,13 +97,15 @@ $path : '../images/';
 
 .code-label {
   text-align: right;
+  width: 100%;
   position: absolute;
   top: 0;
   right: 0;
-  margin: 5px 10px 0 0;
+  padding: 5px 10px 5px 0;
   z-index: 100;
   color: rgba(0, 0, 0, 0.3);
   font-weight: normal;
+  cursor: pointer;
 }
 
 

--- a/pages_builder/pages/forms/summary.yml
+++ b/pages_builder/pages/forms/summary.yml
@@ -35,7 +35,7 @@ examples:
       - Framework
       - Lot
       - Last edited
-      - Action
+      - <span class="hidden">Action</span>
     field_headings_visible: True
     with_action_field: True
     rows:

--- a/pages_builder/pages/forms/summary.yml
+++ b/pages_builder/pages/forms/summary.yml
@@ -2,6 +2,32 @@ pageTitle: Summary
 assetPath: ../govuk_template/assets/
 examples:
   -
+    field_headings:
+      - Subject
+      - Verb
+      - Adjective
+      - Object
+    field_headings_visible: True
+    rows:
+      -
+        fields:
+          - This table
+          - has
+          - "no"
+          - table heading
+      -
+        fields:
+          - This table
+          - has
+          - visible
+          - field headings
+      -
+        fields:
+          - This table
+          - has
+          - three
+          - content rows
+  -
     heading: Summary item with no entries
     empty_message: You haven't submitted any services yet
   -

--- a/toolkit/templates/forms/summary.html
+++ b/toolkit/templates/forms/summary.html
@@ -1,9 +1,11 @@
+{% if heading %}
 <h2 class="summary-item-heading">
     {% if index %}
       <span class="summary-item-heading-number">{{ index }}.</span>
     {% endif %}
     {{ heading }}
 </h2>
+{% endif %}
 {% if top_link %}
   <p class="summary-item-top-level-action">
     <a href="{{ top_link }}" class="summary-change-link">{{ top_link_label }}</a>

--- a/toolkit/templates/forms/summary.html
+++ b/toolkit/templates/forms/summary.html
@@ -15,7 +15,7 @@
       <tr>
         {% for field_heading in field_headings %}
           <th scope="col" class="summary-item-field-heading{% if loop.first %}-first{% endif %}">
-            {{ field_heading }}
+            {{ field_heading|safe }}
           </th>
         {% endfor %}
       </tr>


### PR DESCRIPTION
##### Fix `onclick` behaviour for code examples.

Code examples open when clicked, but would also collapse when
any part of them were clicked.  This meant it was difficult to
practice good CPDD<sup>1</sup>.

##### Allow HTML to be passed to summary table headers

Allow passed-in HTML markup to render in table headers.
This means we can give classes or links to individual table headers.
Same as we did with table cells in a past commit (914d401)

##### Make table heading optional

If no heading is given, no heading appears in the resulting HTML.
Previously, an empty `h2` tag would still be generated.

<sub>1: Copy-Paste Driven Development</sub>