### PR TITLE
Fix hidden table headings

### DIFF
--- a/pages_builder/pages/forms/summary.yml
+++ b/pages_builder/pages/forms/summary.yml
@@ -2,6 +2,7 @@ pageTitle: Summary
 assetPath: ../govuk_template/assets/
 examples:
   -
+    caption: Summary item with no entries
     field_headings:
       - Subject
       - Verb
@@ -31,6 +32,7 @@ examples:
     heading: Summary item with no entries
     empty_message: You haven't submitted any services yet
   -
+    caption: Summary item with column headings
     heading: Summary item with column headings
     field_headings:
       - Name
@@ -54,6 +56,7 @@ examples:
           - Summary item name
           - Summary item content
   -
+    caption: Summary item with many columns
     heading: Summary item with many columns
     field_headings:
       - Name
@@ -74,6 +77,7 @@ examples:
           - 12 June 2015
           - <a href="#">Edit</a>
   -
+    caption: Summary item with wide first column
     heading: Summary item with wide first column
     field_headings:
       - Name
@@ -85,6 +89,7 @@ examples:
           - User access control within management interfaces
           - Yes
   -
+    caption: Summary item with top-level action
     heading: Summary item with top-level action
     field_headings:
       - Name
@@ -97,6 +102,7 @@ examples:
           - Summary item name
           - Summary item content
   -
+    caption: Summary item with number
     heading: Summary item with number
     field_headings:
       - Name
@@ -110,6 +116,7 @@ examples:
           - Summary item content
           - '<a href="#">Change<span class="visuallyhidden"> Summary item</span></a>'
   -
+    caption: Summary item with name field as link
     heading: Summary item with name field as link
     field_headings:
       - Name
@@ -122,6 +129,7 @@ examples:
           - Summary item content
           - '<a href="#">Change<span class="visuallyhidden"> Summary item</span></a>'
   -
+    caption: Summary item with content field as list
     heading: Summary item with content field as list
     field_headings:
       - Name
@@ -132,6 +140,7 @@ examples:
           - Summary item name
           - <ul><li>Summary item content 1</li><li>Summary item content 2</li></ul>
   -
+    caption: Summary item with incomplete entry
     heading: Summary item with incomplete entry
     field_headings:
       - Name

--- a/pages_builder/pages/forms/summary.yml
+++ b/pages_builder/pages/forms/summary.yml
@@ -75,6 +75,9 @@ examples:
           - <a href="#">Edit</a>
   -
     heading: Summary item with wide first column
+    field_headings:
+      - Name
+      - Content
     wide_first_column: True
     rows:
       -
@@ -83,6 +86,9 @@ examples:
           - Yes
   -
     heading: Summary item with top-level action
+    field_headings:
+      - Name
+      - Content
     top_link: "#"
     top_link_label: Add new service
     rows:
@@ -92,6 +98,9 @@ examples:
           - Summary item content
   -
     heading: Summary item with number
+    field_headings:
+      - Name
+      - Content
     index: 1
     with_action_field: True
     rows:
@@ -102,6 +111,9 @@ examples:
           - '<a href="#">Change<span class="visuallyhidden"> Summary item</span></a>'
   -
     heading: Summary item with name field as link
+    field_headings:
+      - Name
+      - Content
     with_action_field: True
     rows:
       -
@@ -111,6 +123,9 @@ examples:
           - '<a href="#">Change<span class="visuallyhidden"> Summary item</span></a>'
   -
     heading: Summary item with content field as list
+    field_headings:
+      - Name
+      - Content
     rows:
       -
         fields:
@@ -118,6 +133,9 @@ examples:
           - <ul><li>Summary item content 1</li><li>Summary item content 2</li></ul>
   -
     heading: Summary item with incomplete entry
+    field_headings:
+      - Name
+      - Content
     top_link: "#"
     top_link_label: Edit <span class="visuallyhidden">summary item with incomplete entry</span>
     rows:

--- a/toolkit/scss/forms/_summary.scss
+++ b/toolkit/scss/forms/_summary.scss
@@ -114,13 +114,10 @@ table.summary-item-body {
   text-align: right;
 }
 
-.summary-item-field-headings {
-
-  tr {
-    position: absolute;
-    left: -9999em;
-  }
-
+.summary-item-field-headings th {
+  height: 0;
+  padding: 0;
+  border: none;
 }
 
 .summary-item-field-headings-visible {

--- a/toolkit/templates/forms/summary.html
+++ b/toolkit/templates/forms/summary.html
@@ -17,7 +17,11 @@
       <tr>
         {% for field_heading in field_headings %}
           <th scope="col" class="summary-item-field-heading{% if loop.first %}-first{% endif %}">
-            {{ field_heading|safe }}
+            {% if field_headings_visible %}
+              {{ field_heading|safe }}
+            {% else %}
+              <span class="visuallyhidden">{{ field_heading|safe }}</span>
+            {% endif %}
           </th>
         {% endfor %}
       </tr>

--- a/toolkit/templates/forms/summary.html
+++ b/toolkit/templates/forms/summary.html
@@ -13,6 +13,9 @@
 {% endif %}
 {% if rows %}
   <table class="summary-item-body">
+    <caption class="visuallyhidden">
+      {{ caption }}
+    </caption>
     <thead class="summary-item-field-headings{% if field_headings_visible %}-visible{% endif %}">
       <tr>
         {% for field_heading in field_headings %}


### PR DESCRIPTION
The previous method of hiding the column headers was causing their containing row to be ignored by accessibility APIs:

![html_node_accessibility_info](https://cloud.githubusercontent.com/assets/87140/8825951/ac07f15a-307a-11e5-8284-1bcb1644d12c.png)

It also meant each table was being identified as two: the hidden row and the rest of the table.

![voiceover_table_information](https://cloud.githubusercontent.com/assets/87140/8825964/c9f32630-307a-11e5-8c45-a77360366104.png)

This fixes that issue and adds captions to all tables meaning they get an accessible label which can be used to identify them in isolation from their place in the document.

![voiceover_table_information_with_captions](https://cloud.githubusercontent.com/assets/87140/8826051/8fed6f8a-307b-11e5-8bd7-1dca2900640c.png)


