### PR TITLE
Add pricing form

### DIFF
--- a/pages_builder/assets/scss/index.scss
+++ b/pages_builder/assets/scss/index.scss
@@ -19,6 +19,7 @@ $path : '../images/';
 @import "forms/_hint.scss";
 @import "forms/_list-entry.scss";
 @import "forms/_option-select.scss";
+@import "forms/_pricing.scss";
 @import "forms/_questions.scss";
 @import "forms/_selection-buttons.scss";
 @import "forms/_summary.scss";

--- a/pages_builder/generate_pages.py
+++ b/pages_builder/generate_pages.py
@@ -212,7 +212,7 @@ class Styleguide_publisher(object):
         page_render = pystache.render(self.template_view, partial)
         print "\n  " + input_file
         print "▸ " + output_file
-        open(output_file, "w+").write(page_render)
+        open(output_file, "w+").write(page_render.encode('utf-8'))
 
     def compile_assets(self, folder):
         print "\nCOMPILING ASSETS from " + folder + "\n"

--- a/pages_builder/pages/forms/index.yml
+++ b/pages_builder/pages/forms/index.yml
@@ -28,6 +28,9 @@ content: >
         <li>
           <a href="upload.html">File upload</a>
         </li>
+        <li>
+          <a href="pricing.html">Pricing</a>
+        </li>
       </ul>
     </div>
   </main>

--- a/pages_builder/pages/forms/pricing.yml
+++ b/pages_builder/pages/forms/pricing.yml
@@ -1,0 +1,20 @@
+pageTitle: Pricing
+assetPath: ../govuk_template/assets/
+examples:
+  -
+    question: Price
+    hint: Hint comprising further information about the price
+    name: price
+
+  - question: Price with default values
+    hint: Hint comprising further information about the price
+    name: price
+    priceMin: 12.12
+    priceMax: 15.15
+    priceUnit: Person
+    priceInterval: Second
+
+  - question: Price with an error
+    name: anotherPrice
+    error: This is not ok
+

--- a/toolkit/scss/forms/_pricing.scss
+++ b/toolkit/scss/forms/_pricing.scss
@@ -1,0 +1,95 @@
+@import "_colours.scss";
+@import "_shims.scss";
+@import "_typography.scss";
+
+.pricing {
+
+  .pricing-column {
+    position: relative;
+    @include inline-block;
+    min-height: 105px;
+    min-width: 2em;
+    margin: 0 10px;
+    vertical-align: bottom;
+
+    @include ie(6) {
+      height: 105px;
+      width: 2em;
+    }
+
+    &:first-child {
+      margin-left: 0;
+    }
+
+    label,
+    .question-hint {
+      @include core-19;
+    }
+
+    label {
+      display: block;
+      width: 8em;
+    }
+
+    .question-hint {
+      margin: 0;
+    }
+
+  }
+
+  .pricing-input {
+
+    width: 100%;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    margin: 0;
+    z-index: 10;
+
+    @include ie-lte(7) {
+      width:75%;
+    }
+
+    &-with-unit {
+      @extend .pricing-input;
+      padding-left: 1.6em;
+    }
+
+    &-select {
+      @extend .pricing-input;
+      margin: 0 0 15px 2%;
+      width: 98%; // Chrome tries to chop the sides off when you make the font bigger
+      font-size: 19px;
+
+      @include ie-lte(8) {
+        width: auto;
+        margin-right: 1px;
+      }
+    }
+
+  }
+
+  .pricing-unit {
+    color: $grey-2;
+    position: absolute;
+    bottom: 12px;
+    left: 10px;
+    z-index: 20;
+    font-weight: bold;
+  }
+
+  .pricing-preposition {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    text-align: center;
+    padding-bottom: 12px;
+  }
+
+}
+
+.visually-hidden {
+  position: absolute;
+  left: -999em;
+}

--- a/toolkit/templates/forms/pricing.html
+++ b/toolkit/templates/forms/pricing.html
@@ -1,0 +1,99 @@
+{% macro _option(label, current) -%}
+  {% if label == current %}
+    <option value='{{ label }}' selected='selected'>{{ label }}</option>
+    {% else %}
+    <option value='{{ label }}'>{{ label }}</option>
+  {% endif %}
+{%- endmacro %}
+
+{% if error %}
+  <div class="validation-wrapper">
+{% endif %}
+  <fieldset class="question first-question">
+    <legend>
+      <span class="question-heading {% if hint %}question-heading-with-hint{% endif %}">
+        {{ question }}
+      </span>
+      {% if hint %}
+        <span class="hint">
+          {{ hint }}
+        </span>
+      {% endif %}
+      {% if error %}
+        <span class="validation-message" id="error-{{ name }}">
+          {{ error }}
+        </span>
+      {% endif %}
+    </legend>
+    <div class="pricing">
+      <div class="pricing-column">
+        <label for="{{ name }}MinPrice">
+          Minimum price
+          <span class="visually-hidden">in</span>
+          <span class="pricing-unit">£</span>
+        </label>
+        <input type="text" class="text-box pricing-input-with-unit" name="{{ name }}" id="{{ name }}MinPrice" value="{{ priceMin }}"/>
+      </div>
+      <div class="pricing-column">
+        <div class="pricing-preposition">to</div>
+      </div>
+      <div class="pricing-column">
+        <label for="{{ name }}MaxPrice">
+          Maximum price
+          <span class="visuall-hidden">in</span>
+          <span class="pricing-unit">£</span>
+        </label>
+        <p class="question-hint">Optional</p>
+        <input type="text" class="text-box pricing-input-with-unit" name="{{ name }}" id="{{ name }}MaxPrice" value="{{ priceMax or "" }}"/>
+      </div>
+      <div class="pricing-column">
+        <span class="pricing-preposition">per</span>
+      </div>
+      <div class="pricing-column">
+        <label for="{{ name }}Unit">
+          Unit
+        </label>
+        <select class="pricing-input-select" name="{{ name }}" id="{{ name }}Unit">
+          {{ _option("", priceUnit) }}
+          {{ _option("Unit", priceUnit) }}
+          {{ _option("Person", priceUnit) }}
+          {{ _option("Licence", priceUnit) }}
+          {{ _option("User", priceUnit) }}
+          {{ _option("Device", priceUnit) }}
+          {{ _option("Instance", priceUnit) }}
+          {{ _option("Server", priceUnit) }}
+          {{ _option("Virtual machine", priceUnit) }}
+          {{ _option("Transaction", priceUnit) }}
+          {{ _option("Megabyte", priceUnit) }}
+          {{ _option("Gigabyte", priceUnit) }}
+          {{ _option("Terabyte", priceUnit) }}
+        </select>
+      </div>
+      <div class="pricing-column">
+        <span class="pricing-preposition">per</span>
+      </div>
+      <div class="pricing-column">
+        <label for="{{ name }}Interval">
+          Interval
+        </label>
+        <p class="question-hint">
+          Optional
+        </p>
+        <select class="pricing-input-select" name="{{ name }}" id="{{ name }}Interval">
+          {{ _option("", priceInterval) }}
+          {{ _option("Second", priceInterval) }}
+          {{ _option("Minute", priceInterval) }}
+          {{ _option("Hour", priceInterval) }}
+          {{ _option("Day", priceInterval) }}
+          {{ _option("Week", priceInterval) }}
+          {{ _option("Month", priceInterval) }}
+          {{ _option("Quarter", priceInterval) }}
+          {{ _option("6 months", priceInterval) }}
+          {{ _option("Year", priceInterval) }}
+        </select>
+      </div>
+    </div>
+  </fieldset>
+{% if error %}
+  </div>
+{% endif %}


### PR DESCRIPTION
Add a template for the pricing form. The markup and SCSS is mostly taken
from the [admin app](alphagov/digitalmarketplace-admin-frontend@86afb5a). This differs from other form templates in that
it is made up of multiple form elements and therefore requires multiple
default values. This is expected to be handled in macros in the
frontends. eg.

```jinja
{% macro pricing(question_content, service_data, errors) -%}
  {%
    with
    name=question_content.id,
    priceMin=service_data.priceMin,
    priceMax=service_data.priceMax,
    priceUnit=service_data.priceUnit,
    priceInterval=service_data.priceInterval,
    hint=question_content.hint,
    error=errors.get(question_content.id)['message']
  %}
    {% include "toolkit/forms/textbox.html" %}
  {% endwith %}
{%- endmacro %}
```

![screen shot 2015-07-29 at 16 41 17](https://cloud.githubusercontent.com/assets/14287/8962124/ccfa1686-3610-11e5-86e4-4df910c37292.png)

![screen shot 2015-07-29 at 16 41 28](https://cloud.githubusercontent.com/assets/14287/8962130/d3edfe26-3610-11e5-8d7c-e0390afa87da.png)
