### PR TITLE
Improve pricing form module

### DIFF
--- a/toolkit/scss/forms/_pricing.scss
+++ b/toolkit/scss/forms/_pricing.scss
@@ -1,8 +1,11 @@
 @import "_colours.scss";
+@import "_measurements.scss";
 @import "_shims.scss";
 @import "_typography.scss";
 
 .pricing {
+  
+  margin-top: $gutter-half;
 
   .pricing-column {
     position: relative;
@@ -33,6 +36,7 @@
 
     .question-hint {
       margin: 0;
+      color: $secondary-text-colour;
     }
 
   }

--- a/toolkit/templates/forms/pricing.html
+++ b/toolkit/templates/forms/pricing.html
@@ -40,7 +40,7 @@
       <div class="pricing-column">
         <label for="{{ name }}MaxPrice">
           Maximum price
-          <span class="visuall-hidden">in</span>
+          <span class="visually-hidden">in</span>
           <span class="pricing-unit">£</span>
         </label>
         <p class="question-hint">Optional</p>


### PR DESCRIPTION
- Add a bit of space between the main hint and the field hints
- Make the word Optional in the field hints grey
- Fix typo in visually-hidden class name

## Before
![screen shot 2015-08-04 at 11 47 11](https://cloud.githubusercontent.com/assets/14287/9059056/9e397f98-3a9e-11e5-8ba8-ff23a6d63d09.png)

## After
![screen shot 2015-08-04 at 11 46 38](https://cloud.githubusercontent.com/assets/14287/9059061/a49f273e-3a9e-11e5-9476-49a8e95586b4.png)
