### PR TITLE
Hint text on supplier app two thirds of page width

### DIFF
--- a/toolkit/scss/forms/_hint.scss
+++ b/toolkit/scss/forms/_hint.scss
@@ -2,6 +2,7 @@
 @import "_typography.scss";
 
 .hint {
+  @include grid-column( 2/3 );
   display: block;
   @include core-19;
   margin: 0 0 5px 0;


### PR DESCRIPTION
Was too long for comfortable reading.