### PR TITLE
Fix summary-table upload field display

### DIFF
--- a/pages_builder/pages/summary-table.yml
+++ b/pages_builder/pages/summary-table.yml
@@ -211,6 +211,10 @@ examples:
           assurance="Independent validation of assertion") }}
       {% endcall %}
       {% call summary.row() %}
+        {{ summary.field_name("Pricing document") }}
+        {{ summary.upload("http://example.com/pricingDocument.pdf") }}
+      {% endcall %}
+      {% call summary.row() %}
         {{ summary.field_name("Description") }}
         {{ summary.textbox_large(
           "An advanced, web-based content management system that helps users create, manage and publish content quickly and easily."

--- a/toolkit/templates/summary-table.html
+++ b/toolkit/templates/summary-table.html
@@ -151,8 +151,8 @@
 
 {% macro upload(value, assurance=None) -%}
   {% call field() %}
-    {% if 'url' in value and 'filename' in value %}
-      <a href="{{ value.url }}">{{ value.filename }}</a>
+    {% if value %}
+      <a href="{{ value }}">{{ value.split("/")[-1] }}</a>
     {% endif %}
   {% endcall %}
 {%- endmacro %}


### PR DESCRIPTION
Since presenters aren't used for the summary-table the macro value
argument is the document URL instead of a `{url, filename}` dict.

The macro not does the same filename processing that the upload
presenter used to do.