### PR TITLE
Add question numbers

### DIFF
--- a/pages_builder/pages/forms/question-and-answer-format.yml
+++ b/pages_builder/pages/forms/question-and-answer-format.yml
@@ -46,3 +46,19 @@ examples:
             Answer 5
           </label>
         </fieldset>
+  -
+    title: Numbered question
+    markup: >
+      <form action="" method="get">
+        <div class="question first-question">
+          <label for="question-1" class="question-heading question-heading-with-hint">
+            <span class="question-number">
+              12
+            </span>
+            What was the name of your first pet?
+          </label>
+          <p class="hint">
+            the question and answer are wrapped in a div with the question the answer field's label
+          </p>
+          <input type="text" name="question-1" id="question-1" class="text-box" value="" />
+        </div>

--- a/toolkit/scss/forms/_questions.scss
+++ b/toolkit/scss/forms/_questions.scss
@@ -31,3 +31,31 @@
   margin: 0 0 10px 0;
   clear: left;
 }
+
+.question-number {
+
+  @include bold-24;
+  display: block;
+  margin-bottom: -20px;
+
+  &:after {
+    content: ".";
+  }
+
+  @include media(1080px) {
+
+    position: relative;
+    height: 50px;
+    display: block;
+    margin: 20px 0 -50px 0;
+    left: -100px;
+    width: 80px;
+    text-align: right;
+
+    &:after {
+      content: "";
+    }
+
+  }
+
+}

--- a/toolkit/templates/forms/list-entry.html
+++ b/toolkit/templates/forms/list-entry.html
@@ -7,6 +7,11 @@
   <fieldset class="question {% if first_question %}first-question{% endif %}" id="{{ id }}">
     <legend>
       <span class="question-heading {% if hint is defined %}question-heading-with-hint{% endif %}">
+        {% if question_number %}
+          <span class="question-number">
+            {{ question_number }}
+          </span>
+        {% endif %}
         {{ question }}
       </span>
       {% if hint %}

--- a/toolkit/templates/forms/selection-buttons.html
+++ b/toolkit/templates/forms/selection-buttons.html
@@ -4,7 +4,12 @@
   <fieldset class="question first-question">
     <legend>
       <span class="question-heading {% if hint is defined %}question-heading-with-hint{% endif %}">
-          {{ question }}
+        {% if question_number %}
+          <span class="question-number">
+            {{ question_number }}
+          </span>
+        {% endif %}
+        {{ question }}
       </span>
       {% if hint %}
         <span class="hint">
@@ -33,7 +38,7 @@
           {% if type == "radio" %}
             <input type="{{ type }}" name="{{ name }}" id="{{ name }}-{{ loop.index }}" value="{{ option.value or option.label }}" {% if option.label == value %}checked="checked"{% endif %} />
           {% elif type == "checkbox" %}
-            <input type="{{ type }}" name="{{ name }}" id="{{ name }}-{{ loop.index }}" value="{{ option.value or option.label }}" {% if option.label in value %}checked="checked"{% endif %} />  
+            <input type="{{ type }}" name="{{ name }}" id="{{ name }}-{{ loop.index }}" value="{{ option.value or option.label }}" {% if option.label in value %}checked="checked"{% endif %} />
           {% endif %}
         </label>
         {% if option.description is defined %}

--- a/toolkit/templates/forms/textbox.html
+++ b/toolkit/templates/forms/textbox.html
@@ -4,6 +4,11 @@
   <div class="question">
     <label for="{{ name }}">
       <span class="question-heading{% if hint is defined %}-with-hint{% endif %}">
+        {% if question_number %}
+          <span class="question-number">
+            {{ question_number }}
+          </span>
+        {% endif %}
         {{ question }}
         {% if unit_in_full %}
           <span class="text-box-unit-qualifier">(in {{ unit_in_full }})</span>

--- a/toolkit/templates/forms/upload.html
+++ b/toolkit/templates/forms/upload.html
@@ -4,6 +4,11 @@
   <div class="question">
     <label for="{{ name }}">
       <span class="question-heading{% if hint is defined %}-with-hint{% endif %}">
+        {% if question_number %}
+          <span class="question-number">
+            {{ question_number }}
+          </span>
+        {% endif %}
         {{ question }}
       </span>
       {% if hint %}


### PR DESCRIPTION
These are currently used in the supplier declaration, but the semantics aren't great because there's no way of injecting them into the label/legend of a field template in the toolkit.

This commit adds the option to pass in a number to each field template.

![image](https://cloud.githubusercontent.com/assets/355079/9246462/94a77fbe-41a3-11e5-9cf4-46a64d6fe810.png)
