### PR TITLE
Fix problems with Jinja examples

### DIFF
--- a/pages_builder/parameters_template.html
+++ b/pages_builder/parameters_template.html
@@ -2,8 +2,8 @@
 {%
   with' }}
 {%- for key, value in parameters.iteritems() %}
-  {{ key }} = {{ value }},
+  {{ key }} = {{ value }}{% if not loop.last %},{% endif %}
 {%- endfor %}
 {{ '%}' }}
-  {{ '{% include "toolkit/templates/' }}{{ file }}{{ '.html" %}' }}
+  {{ '{% include "toolkit/' }}{{ file }}{{ '.html" %}' }}
 {{ '{% endwith %}' }}


### PR DESCRIPTION
As described here: https://www.pivotaltracker.com/story/show/100557872

--

Paths to resources in the Jinja examples have an extra `/template/` in them, eg
```jinja
{% include "toolkit/templates//button.html" %}
```
instead of:
```jinja
{% include "toolkit/button.html" %}
```

Also there is a problem with trailing commas – trailing commas at the end of `with` clauses is not valid Jinja syntax, eg
```jinja
{% with
    message = "With plain text",
    type = "success",
%}
```
should be:
```jinja
{% with
    message = "With plain text",
    type = "success"
%}
```