### PR TITLE
Add grids to form content

### DIFF
--- a/pages_builder/generate_pages.py
+++ b/pages_builder/generate_pages.py
@@ -107,6 +107,11 @@ class Styleguide_publisher(object):
             }
         )
 
+    def render_include(self, include_file_name, data):
+        template_file = os.path.join(self.repo_root, "pages_builder", "includes", include_file_name)
+        template = open(template_file, "r").read()
+        return pystache.render(template, data)
+
     def render_page(self, root, file):
         input_file = os.path.join(root, file)
         output_file = self.__get_page_filename(input_file)
@@ -147,67 +152,30 @@ class Styleguide_publisher(object):
                         "highlighted_markup": highlight(example_markup, HtmlLexer(), HtmlFormatter(noclasses=True))
 
                     })
-                partial['content'] = pystache.render(
-                    """
-                        <div id="global-breadcrumb" class="header-context">
-                          <nav>
-                            <ol class="group" role="breadcrumbs">
-                              <li>
-                                <a href="{{urlRoot}}/">Home</a>
-                              </li>
-                            </ol>
-                          </nav>
-                        </div>
-                        <main role="main" id="content" class="wrapper">
-                            <div id="wrapper">
-                                <header class="page-heading">
-                                    <h1>{{pageHeading}}</h1>
-                                </header>
-                                {{#pageDescription}}
-                                <div>
-                                    {{{pageDescription}}}
-                                </div>
-                                {{/pageDescription}}
-                                {{#examples}}
-                                    {{#title}}<h2>{{title}}</h2>{{/title}}
-                                    {{{markup}}}
-                                    <div class="code open" data-lang="jinja"><h3 class="code-label">Jinja</h3>{{{parameters}}}</div>
-                                    <div class="code open" data-lang="html"><h3 class="code-label">HTML</h3>{{{highlighted_markup}}}</div>
-                                {{/examples}}
-                            </div>
-                        </main>
-                    """, {
-                        "examples": examples,
-                        "pageTitle": partial['pageTitle'],
-                        "pageDescription": partial.get('pageDescription'),
-                        "pageHeading": partial['pageHeading'],
-                        "templateFile": template_file,
-                        "urlRoot": url_root
-                    }
+                partial_data = {
+                    "examples": examples,
+                    "pageTitle": partial['pageTitle'],
+                    "pageDescription": partial.get('pageDescription'),
+                    "pageHeading": partial['pageHeading'],
+                    "templateFile": template_file,
+                    "urlRoot": url_root
+                }
+                partial['content'] = self.render_include(
+                    os.path.join(self.repo_root, "pages_builder", "includes", "content.html"),
+                    partial_data
                 )
 
-        partial['head'] = (
-            '<!--[if !IE]><!-->'
-            '<link rel="stylesheet" href="' + url_root + '/public/stylesheets/index.css "/>'  # noqa
-            '<!--<![endif]-->'
-            '<!--[if IE 6]>'
-            '<link rel="stylesheet" href="' + url_root + '/public/stylesheets/index-ie6.css "/>'  # noqa
-            '<![endif]-->'
-            '<!--[if IE 7]>'
-            '<link rel="stylesheet" href="' + url_root + '/public/stylesheets/index-ie7.css "/>'  # noqa
-            '<![endif]-->'
-            '<!--[if IE 8]>'
-            '<link rel="stylesheet" href="' + url_root + '/public/stylesheets/index-ie8.css "/>'  # noqa
-            '<![endif]-->'
-            '<!--[if IE 9]>'
-            '<link rel="stylesheet" href="' + url_root + '/public/stylesheets/index-ie9.css "/>'  # noqa
-            '<![endif]-->'
+        partial['head'] = self.render_include(
+            os.path.join(self.repo_root, "pages_builder", "includes", "head.html"),
+            { "url_root": url_root }
         )
         bodyEnd = partial['bodyEnd'] if "bodyEnd" in partial else ""
-        partial['bodyEnd'] = (
-            '<script type="text/javascript" src="' + url_root + '/public/javascripts/vendor/jquery-1.11.0.js"></script>' +  # noqa
-            bodyEnd +
-            '<script type="text/javascript" src="' + url_root + '/public/javascripts/onready.js"></script>'  # noqa
+        partial['bodyEnd'] = self.render_include(
+            os.path.join(self.repo_root, "pages_builder", "includes", "bodyEnd.html"),
+            {
+                "url_root": url_root,
+                "bodyEnd": bodyEnd
+            }
         )
         page_render = pystache.render(self.template_view, partial)
         print "\n  " + input_file

--- a/pages_builder/generate_pages.py
+++ b/pages_builder/generate_pages.py
@@ -160,6 +160,9 @@ class Styleguide_publisher(object):
                     "templateFile": template_file,
                     "urlRoot": url_root
                 }
+                if "grid" in partial:
+                    partial_data['grid'] = partial['grid']
+
                 partial['content'] = self.render_include(
                     os.path.join(self.repo_root, "pages_builder", "includes", "content.html"),
                     partial_data

--- a/pages_builder/includes/bodyEnd.html
+++ b/pages_builder/includes/bodyEnd.html
@@ -1,0 +1,3 @@
+<script type="text/javascript" src="{{ url_root }}/public/javascripts/vendor/jquery-1.11.0.js"></script>
+{{{ bodyEnd }}}
+<script type="text/javascript" src="{{ url_root }}/public/javascripts/onready.js"></script>

--- a/pages_builder/includes/content.html
+++ b/pages_builder/includes/content.html
@@ -1,0 +1,35 @@
+<div id="global-breadcrumb" class="header-context">
+  <nav>
+    <ol class="group" role="breadcrumbs">
+      <li>
+        <a href="{{urlRoot}}/">Home</a>
+      </li>
+    </ol>
+  </nav>
+</div>
+<main role="main" id="content" class="wrapper">
+    <div id="wrapper">
+        <header class="page-heading">
+            <h1>{{pageHeading}}</h1>
+        </header>
+        {{#pageDescription}}
+        <div>
+            {{{pageDescription}}}
+        </div>
+        {{/pageDescription}}
+        {{#grid}}
+        <div class="grid-row">
+            <div class="{{grid}}">
+        {{/grid}}
+        {{#examples}}
+            {{#title}}<h2>{{title}}</h2>{{/title}}
+            {{{markup}}}
+        {{#grid}}
+            </div>
+        </div>
+        {{/grid}}
+            <div class="code open" data-lang="jinja"><h3 class="code-label">Jinja</h3>{{{parameters}}}</div>
+            <div class="code open" data-lang="html"><h3 class="code-label">HTML</h3>{{{highlighted_markup}}}</div>
+        {{/examples}}
+    </div>
+</main>

--- a/pages_builder/includes/content.html
+++ b/pages_builder/includes/content.html
@@ -17,11 +17,11 @@
             {{{pageDescription}}}
         </div>
         {{/pageDescription}}
+        {{#examples}}
         {{#grid}}
         <div class="grid-row">
             <div class="{{grid}}">
         {{/grid}}
-        {{#examples}}
             {{#title}}<h2>{{title}}</h2>{{/title}}
             {{{markup}}}
         {{#grid}}

--- a/pages_builder/includes/head.html
+++ b/pages_builder/includes/head.html
@@ -1,0 +1,15 @@
+<!--[if !IE]><!-->
+<link rel="stylesheet" href="{{ url_root }}/public/stylesheets/index.css "/>
+<!--<![endif]-->
+<!--[if IE 6]>
+<link rel="stylesheet" href="{{ url_root }}/public/stylesheets/index-ie6.css "/>
+<![endif]-->
+<!--[if IE 7]>
+<link rel="stylesheet" href="{{ url_root }}/public/stylesheets/index-ie7.css "/>
+<![endif]-->
+<!--[if IE 8]>
+<link rel="stylesheet" href="{{ url_root }}/public/stylesheets/index-ie8.css "/>
+<![endif]-->
+<!--[if IE 9]>
+<link rel="stylesheet" href="{{ url_root }}/public/stylesheets/index-ie9.css "/>
+<![endif]-->

--- a/pages_builder/pages/forms/list-entry.yml
+++ b/pages_builder/pages/forms/list-entry.yml
@@ -1,5 +1,6 @@
 pageTitle: List entry
 assetPath: ../govuk_template/assets/
+grid: two-third-column
 bodyEnd: >
   <script type="text/javascript" src="../public/javascripts/vendor/hogan-3.0.2.min.js"></script>
   <script type="text/javascript" src="../public/javascripts/list-entry.js"></script>

--- a/pages_builder/pages/forms/option-select.yml
+++ b/pages_builder/pages/forms/option-select.yml
@@ -1,5 +1,6 @@
 pageTitle: Option select
 assetPath: ../govuk_template/assets/
+grid: third-column
 bodyEnd: >
   <script type="text/javascript" src="../public/javascripts/option-select.js"></script>
 examples:

--- a/pages_builder/pages/forms/pricing.yml
+++ b/pages_builder/pages/forms/pricing.yml
@@ -1,5 +1,6 @@
 pageTitle: Pricing
 assetPath: ../govuk_template/assets/
+grid: two-third-column
 examples:
   -
     question: Price

--- a/pages_builder/pages/forms/selection-buttons.yml
+++ b/pages_builder/pages/forms/selection-buttons.yml
@@ -1,5 +1,6 @@
 pageTitle: Selection buttons
 assetPath: ../govuk_template/assets/
+grid: two-third-column
 bodyEnd: >
   <script type="text/javascript" src="../public/javascripts/govuk_frontend_toolkit/vendor/polyfills/bind.js"></script>
   <script type="text/javascript" src="../public/javascripts/govuk_frontend_toolkit/govuk/selection-buttons.js"></script>

--- a/pages_builder/pages/forms/textbox.yml
+++ b/pages_builder/pages/forms/textbox.yml
@@ -1,5 +1,6 @@
 pageTitle: Textboxes
 assetPath: ../govuk_template/assets/
+grid: two-third-column
 bodyEnd: >
   <script type="text/javascript" src="../public/javascripts/vendor/hogan-3.0.2.min.js"></script>
   <script type="text/javascript" src="../public/javascripts/word-counter.js"></script>

--- a/pages_builder/pages/forms/upload.yml
+++ b/pages_builder/pages/forms/upload.yml
@@ -1,5 +1,6 @@
 pageTitle: File upload
 assetPath: ../govuk_template/assets/
+grid: two-third-column
 examples:
   -
     question: Please upload a file

--- a/pages_builder/pages/search-results.yml
+++ b/pages_builder/pages/search-results.yml
@@ -1,5 +1,6 @@
 pageTitle: Search result
 assetPath: govuk_template/assets/
+grid: two-third-column
 examples:
   -
     title: Search results

--- a/pages_builder/pages/search-summary.yml
+++ b/pages_builder/pages/search-summary.yml
@@ -1,5 +1,6 @@
 pageTitle: Search summary
 assetPath: govuk_template/assets/
+grid: two-third-column
 examples:
   -
     title: Search summary

--- a/toolkit/scss/forms/_list-entry.scss
+++ b/toolkit/scss/forms/_list-entry.scss
@@ -8,16 +8,38 @@
   .list-entry {
     vertical-align: middle;
     margin-bottom: 15px;
+    position: relative;
+
+    @include ie-lte(7) {
+      zoom: 1;
+    }
+
+    @include media(tablet) {
+      .text-box {
+        width: 100%;
+      }
+    }
   }
 
   .list-entry-remove {
     @include core-19;
     display: block;
     margin-bottom: 15px;
+    margin-top: 5px;
+    position: static;
 
-    @include media(desktop) {
+    @include media(tablet) {
       @include inline-block;
       margin: 0 0 0 0.6em;
+      position: absolute;
+      top: 6px; /* height of textbox minus its top-padding */
+      left: 100%;
+      margin-left: 0.6em;
+    }
+
+    @include ie-lte(7) {
+      top: auto;
+      left: 110%;
     }
   }
 

--- a/toolkit/scss/forms/_pricing.scss
+++ b/toolkit/scss/forms/_pricing.scss
@@ -7,6 +7,12 @@
   
   margin-top: $gutter-half;
 
+  @include media($min-width: 900px) {
+    .two-third-column & {
+      margin-right: -100%;
+    }
+  }
+
   .pricing-column {
     position: relative;
     @include inline-block;
@@ -14,6 +20,25 @@
     min-width: 2em;
     margin: 0 10px;
     vertical-align: bottom;
+
+    .two-third-column & {
+      min-height: 0;
+      width: 100%;
+      margin-left: 0;
+      margin-top: $gutter-half;
+
+      @include media($min-width: 900px) {
+        min-height: 105px;
+        width: auto;
+        margin-left: 10px;
+        margin-top: 0;
+      }
+    }
+
+    /* IE7's font rendering meant some of the text was obscured with the default min-height */
+    @include ie-lte(7) {
+      min-height: 115px;
+    }
 
     @include ie(6) {
       height: 105px;
@@ -44,33 +69,40 @@
   .pricing-input {
 
     width: 100%;
-    position: absolute;
+    position: static;
     bottom: 0;
     left: 0;
     margin: 0;
     z-index: 10;
 
+    @include media($min-width: 900px) {
+      position: absolute;
+    }
+
     @include ie-lte(7) {
       width:75%;
     }
+  }
 
-    &-with-unit {
-      @extend .pricing-input;
-      padding-left: 1.6em;
+  .pricing-input-with-unit {
+    @extend .pricing-input;
+    padding-left: 1.6em;
+  }
+
+  .pricing-input-select {
+    @extend .pricing-input;
+    margin: 0 0 15px 0;
+    width: 98%; // Chrome tries to chop the sides off when you make the font bigger
+    font-size: 19px;
+
+    @include media($min-width: 900px) {
+      margin-left: 0;
     }
 
-    &-select {
-      @extend .pricing-input;
-      margin: 0 0 15px 2%;
-      width: 98%; // Chrome tries to chop the sides off when you make the font bigger
-      font-size: 19px;
-
-      @include ie-lte(8) {
-        width: auto;
-        margin-right: 1px;
-      }
+    @include ie-lte(8) {
+      width: auto;
+      margin-right: 1px;
     }
-
   }
 
   .pricing-unit {
@@ -89,6 +121,11 @@
     width: 100%;
     text-align: center;
     padding-bottom: 12px;
+    display: none;
+
+    @include media($min-width: 900px) {
+      display: block;
+    }
   }
 
 }

--- a/toolkit/scss/forms/_textboxes.scss
+++ b/toolkit/scss/forms/_textboxes.scss
@@ -13,9 +13,11 @@
   margin: 0 0 15px 0;
   padding: 5px;
   border: 1px solid $border-colour;
+  width: 100%;
 
-  @include media(desktop){
-    width: 66%;
+  /* IE<8 cannot include borders and padding as part of width */
+  @include ie-lte(7) {
+    width: 98%;
   }
 }
 

--- a/toolkit/scss/forms/_word-counter.scss
+++ b/toolkit/scss/forms/_word-counter.scss
@@ -13,8 +13,5 @@
   margin: 5px 0 0 0;
   padding: 0;
   color: $secondary-text-colour;
-
-  @include media(desktop) {
-    width: 66%;
-  }
+  width: 100%;
 }


### PR DESCRIPTION
This includes changes to the CSS for the forms patterns so their horizontal spacing is controlled by the grid instead of being defined in their CSS. One of these grids has also been added to each of the form patterns example pages to show the expected use.

This work includes changes to the code that generates the pages to allow them to have grids to wrap the pattern. You now just need to add a `grid` parameter containing the class name of the column type, for example:

https://github.com/alphagov/digitalmarketplace-frontend-toolkit/blob/add-grids-to-form-content/pages_builder/pages/forms/textbox.yml#L3

The input list and pricing patterns have both had additional changes made to their CSS to allow them to work when sitting inside a two-thirds grid column:

![input_list](https://cloud.githubusercontent.com/assets/87140/9962357/49b8ef24-5e1d-11e5-92aa-6ba059fbe577.png)

![pricing](https://cloud.githubusercontent.com/assets/87140/9962362/507d804a-5e1d-11e5-961e-244ba9acea70.png)

The pricing pattern has also been made to work for mobile screens which involved some consultation with @quis:

![pricing_mobile_view](https://cloud.githubusercontent.com/assets/87140/9962396/74040e3a-5e1d-11e5-8a11-70c611282076.png)
