### PR TITLE
Make grids match govuk toolkit examples

### DIFF
--- a/pages_builder/assets/scss/grids/index.scss
+++ b/pages_builder/assets/scss/grids/index.scss
@@ -3,27 +3,6 @@
 @import "_colours.scss";
 @import "_css3.scss";
 
-.grid-row {
-  @extend %grid-row;
-  @extend %outdent-to-full-width;
-
-  .third-column {
-    @include grid-column(1/3);
-  }
-  .two-third-column {
-    @include grid-column(2/3);
-  }
-  .quarter-column {
-    @include grid-column(1/4);
-  }
-  .half-column {
-    @include grid-column(1/2);
-  }
-  .one-column {
-    @include grid-column(1/1);
-  }
-}
-
 .grid-example {
   background: rgba($red, 0.1);
   box-shadow:

--- a/pages_builder/assets/scss/index.scss
+++ b/pages_builder/assets/scss/index.scss
@@ -1,8 +1,8 @@
 $path : '../images/';
-@import "grids/index.scss";
 @import "colours";
 
 // Toolkit components
+@import "_grids";
 @import "_phase-banner.scss";
 @import "_breadcrumb.scss";
 @import "_buttons.scss";
@@ -29,6 +29,8 @@ $path : '../images/';
 @import "forms/_word-counter.scss";
 @import "forms/_upload.scss";
 
+// Styles for example pages
+@import "grids/index.scss";
 
 #wrapper {
   @extend %site-width-container;

--- a/pages_builder/pages/forms/list-entry.yml
+++ b/pages_builder/pages/forms/list-entry.yml
@@ -1,6 +1,6 @@
 pageTitle: List entry
 assetPath: ../govuk_template/assets/
-grid: two-third-column
+grid: column-two-thirds
 bodyEnd: >
   <script type="text/javascript" src="../public/javascripts/vendor/hogan-3.0.2.min.js"></script>
   <script type="text/javascript" src="../public/javascripts/list-entry.js"></script>

--- a/pages_builder/pages/forms/pricing.yml
+++ b/pages_builder/pages/forms/pricing.yml
@@ -1,6 +1,6 @@
 pageTitle: Pricing
 assetPath: ../govuk_template/assets/
-grid: two-third-column
+grid: column-two-thirds
 examples:
   -
     question: Price

--- a/pages_builder/pages/forms/selection-buttons.yml
+++ b/pages_builder/pages/forms/selection-buttons.yml
@@ -1,6 +1,6 @@
 pageTitle: Selection buttons
 assetPath: ../govuk_template/assets/
-grid: two-third-column
+grid: column-two-thirds
 bodyEnd: >
   <script type="text/javascript" src="../public/javascripts/govuk_frontend_toolkit/vendor/polyfills/bind.js"></script>
   <script type="text/javascript" src="../public/javascripts/govuk_frontend_toolkit/govuk/selection-buttons.js"></script>

--- a/pages_builder/pages/forms/textbox.yml
+++ b/pages_builder/pages/forms/textbox.yml
@@ -1,6 +1,6 @@
 pageTitle: Textboxes
 assetPath: ../govuk_template/assets/
-grid: two-third-column
+grid: column-two-thirds
 bodyEnd: >
   <script type="text/javascript" src="../public/javascripts/vendor/hogan-3.0.2.min.js"></script>
   <script type="text/javascript" src="../public/javascripts/word-counter.js"></script>

--- a/pages_builder/pages/forms/upload.yml
+++ b/pages_builder/pages/forms/upload.yml
@@ -1,6 +1,6 @@
 pageTitle: File upload
 assetPath: ../govuk_template/assets/
-grid: two-third-column
+grid: column-two-thirds
 examples:
   -
     question: Please upload a file

--- a/pages_builder/pages/grids.yml
+++ b/pages_builder/pages/grids.yml
@@ -29,7 +29,7 @@ examples:
     title: Two columns, 2/3 and 1/3
     items:
       -
-        type: two-third-column
+        type: column-two-thirds
         contents: Contents
       -
         type: column-one-third

--- a/pages_builder/pages/grids.yml
+++ b/pages_builder/pages/grids.yml
@@ -5,25 +5,25 @@ examples:
     title: One column, full width
     items:
       -
-        type: one-column
+        type: column-one-whole
         contents: Contents
   -
     title: Two columns, 1/3 and 2/3
     items:
       -
-        type: third-column
+        type: column-one-third
         contents: Contents
       -
-        type: third-column
+        type: column-two-thirds
         contents: Contents
   -
     title: Two columns, 1/2 and 1/2
     items:
       -
-        type: half-column
+        type: column-one-half
         contents: Contents
       -
-        type: half-column
+        type: column-one-half
         contents: Contents
   -
     title: Two columns, 2/3 and 1/3
@@ -32,5 +32,5 @@ examples:
         type: two-third-column
         contents: Contents
       -
-        type: third-column
+        type: column-one-third
         contents: Contents

--- a/pages_builder/pages/search-results.yml
+++ b/pages_builder/pages/search-results.yml
@@ -1,6 +1,6 @@
 pageTitle: Search result
 assetPath: govuk_template/assets/
-grid: two-third-column
+grid: column-two-thirds
 examples:
   -
     title: Search results

--- a/pages_builder/pages/search-summary.yml
+++ b/pages_builder/pages/search-summary.yml
@@ -1,6 +1,6 @@
 pageTitle: Search summary
 assetPath: govuk_template/assets/
-grid: two-third-column
+grid: column-two-thirds
 examples:
   -
     title: Search summary

--- a/toolkit/scss/_grids.scss
+++ b/toolkit/scss/_grids.scss
@@ -1,0 +1,29 @@
+@import "_grid_layout.scss";
+
+.grid-row {
+  @extend %grid-row;
+}
+
+.column-one-whole {
+  @include grid-column( 1 );
+}
+
+.column-one-half {
+  @include grid-column( 1/2 );
+}
+
+.column-one-third {
+  @include grid-column( 1/3 );
+}
+
+.column-two-thirds {
+  @include grid-column( 2/3 );
+}
+
+.column-one-quarter {
+  @include grid-column( 1/4 );
+}
+
+.column-three-quarters {
+  @include grid-column( 3/4 );
+}

--- a/toolkit/scss/forms/_pricing.scss
+++ b/toolkit/scss/forms/_pricing.scss
@@ -8,7 +8,7 @@
   margin-top: $gutter-half;
 
   @include media($min-width: 900px) {
-    .two-third-column & {
+    .column-two-thirds & {
       margin-right: -100%;
     }
   }
@@ -21,7 +21,7 @@
     margin: 0 10px;
     vertical-align: bottom;
 
-    .two-third-column & {
+    .column-two-thirds & {
       min-height: 0;
       width: 100%;
       margin-left: 0;

--- a/toolkit/templates/grids.html
+++ b/toolkit/templates/grids.html
@@ -1,6 +1,6 @@
 <div class="grid-row">
   {% for item in items %}
-    <div class="grid-column {{ item.type }} grid-example">
+    <div class="{{ item.type }} grid-example">
       <p>{{ item.contents }}</p>
     </div>
   {% endfor %}


### PR DESCRIPTION
The supplier and buyer apps both use the class names suggested by the govuk front-end toolkit rather than those used on our [grids page](http://alphagov.github.io/digitalmarketplace-frontend-toolkit/grids.html):

- [buyers app grids scss](https://github.com/alphagov/digitalmarketplace-buyer-frontend/blob/master/app/assets/scss/_grids.scss)
- [suppliers app grids scss](https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/master/app/assets/scss/_grids.scss)

It's important that we use the same classes across all the apps because some of the styles that make the form content work inside grids are tied to them (see [this example](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/blob/master/toolkit/scss/forms/_pricing.scss#L11)).

I propose we use the class names most in use across our stack, this switches to them in the toolkit.