### PR TITLE
Format service IDs

### DIFF
--- a/pages_builder/pages/summary-table.yml
+++ b/pages_builder/pages/summary-table.yml
@@ -48,9 +48,9 @@ examples:
     {{ summary.heading("Summary table with many columns") }}
     {% call(item) summary.list_table(
       [
-        {"name": "Service 1", "lot": "SCS",  "id": ["1234", "5678", "9012", "3456"], "date": "12 June 2015", "framework": "G-Cloud 6"},
-        {"name": "Service 2", "lot": "SaaS", "id": ["5678", "9012", "1234", "3456"], "date": "12 June 2015", "framework": "G-Cloud 6"},
-        {"name": "Service 2", "lot": "IaaS", "id": ["9012", "1234", "5678", "3456"], "date": "12 June 2015", "framework": "G-Cloud 6"},
+        {"name": "Service 1", "lot": "SCS",  "id": "1234567890123456", "date": "12 June 2015", "framework": "G-Cloud 6"},
+        {"name": "Service 2", "lot": "SaaS", "id": "5678901212343456", "date": "12 June 2015", "framework": "G-Cloud 6"},
+        {"name": "Service 2", "lot": "IaaS", "id": "9012123456783456", "date": "12 June 2015", "framework": "G-Cloud 6"},
       ],
       caption="Summary table with many columns",
       empty_message="You haven't submited any services yet",

--- a/toolkit/templates/summary-table.html
+++ b/toolkit/templates/summary-table.html
@@ -161,9 +161,13 @@
 {% macro service_id(value='', assurance=None) -%}
   {% call field() %}
     <div class="service-id">
-      {% for chunk in value -%}
-        <span class="service-id-chunk">{{ chunk }}</span>
+    {% if value is string and value.isdigit %}
+      {% for chunk in value|slice(4) -%}
+        <span class="service-id-chunk">{{ chunk|join('') }}</span>
       {%- endfor %}
+    {% else %}
+        <span class="service-id-chunk">{{ value }}</span>
+    {% endif %}
     </div>
   {% endcall %}
 {%- endmacro %}


### PR DESCRIPTION
Format service IDs

This change splits service IDs for display if they are all digits. This functionality was previously implemented in the applications.