### PR TITLE
Fixes to scripts

### DIFF
--- a/pages_builder/push_to_github_pages.sh
+++ b/pages_builder/push_to_github_pages.sh
@@ -17,7 +17,6 @@ then
   exit 0
 fi
 
-current_branch=$(git rev-parse --abbrev-ref HEAD)
 build_from=$1
 destination_repo=git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git
 destination_branch=gh-pages

--- a/pages_builder/tag_latest_version.sh
+++ b/pages_builder/tag_latest_version.sh
@@ -8,7 +8,7 @@ git pull origin master
 commit=$(git log master --pretty=oneline --abbrev-commit --no-decorate | grep "Bump version to" | head -n1)
 sha=$(echo $commit | cut -d ' ' -f1)
 version=v$(cat VERSION.txt)
-previous_version=$(git tag|tail -n1)
+previous_version=$(git describe --abbrev=0 ${version}^)
 changes=$(git log --merges --oneline $previous_version..$sha)
 echo Commit:\ \ \ $commit
 echo Version:\ \ $version


### PR DESCRIPTION
## Use git describe to find previous version

`git tag` returns tags alphabetically, not by date.

`git describe` is the appropriate command, thanks Stack Overflow: http://stackoverflow.com/a/14337129/147318

## Remove redundant line
-1