### PR TITLE
Fix tagging of versions

### DIFF
--- a/pages_builder/tag_latest_version.sh
+++ b/pages_builder/tag_latest_version.sh
@@ -8,8 +8,8 @@ git pull origin master
 commit=$(git log master --pretty=oneline --abbrev-commit --no-decorate | grep "Bump version to" | head -n1)
 sha=$(echo $commit | cut -d ' ' -f1)
 version=v$(cat VERSION.txt)
-previous_version=$(git describe --abbrev=0 ${version}^)
-changes=$(git log --merges --oneline $previous_version..$sha)
+previous_version=$(git describe --abbrev=0)
+changes=$(git log --merges --oneline $previous_version..head)
 echo Commit:\ \ \ $commit
 echo Version:\ \ $version
 echo Previous:\ $previous_version


### PR DESCRIPTION
- get the previous version by looking at the most recent tag to head before creating the new tag
- show changes up to head instead of up to version bump, because a merge happens after a version bump commit if they're bundled in one PR