### PR TITLE
[#105005304] Add framework-notice template (in addition to temporary-message)

### DIFF
--- a/pages_builder/assets/scss/index.scss
+++ b/pages_builder/assets/scss/index.scss
@@ -17,6 +17,7 @@ $path : '../images/';
 @import "_service-id.scss";
 @import "_link-button.scss";
 @import "_temporary-message.scss";
+@import "_framework-notice.scss";
 @import "search/_search-summary.scss";
 @import "forms/_hint.scss";
 @import "forms/_list-entry.scss";

--- a/pages_builder/generate_pages.py
+++ b/pages_builder/generate_pages.py
@@ -13,6 +13,7 @@ from jinja2 import Environment, FileSystemLoader, Template
 from pygments import highlight
 from pygments.lexers import HtmlLexer, DjangoLexer
 from pygments.formatters import HtmlFormatter
+from dmutils.filters import markdown_filter
 
 
 class Styleguide_publisher(object):
@@ -134,6 +135,9 @@ class Styleguide_publisher(object):
                 env = Environment(
                     loader=FileSystemLoader(os.path.join(self.repo_root, "toolkit/templates"))
                 )
+                env.filters.update({
+                    'markdown': markdown_filter,
+                })
 
                 template_file = os.path.join(template_subfolder, template_name + ".html")
                 template = env.get_template(template_file)

--- a/pages_builder/pages/framework-notice.yml
+++ b/pages_builder/pages/framework-notice.yml
@@ -21,4 +21,5 @@ examples:
 
       [Create an account](https://www.digitalmarketplace.service.gov.uk/) to receive an email when Digital Outcomes and Specialists opens.
 
+
       [Find out how to apply](https://www.digitalmarketplace.service.gov.uk/)

--- a/pages_builder/pages/framework-notice.yml
+++ b/pages_builder/pages/framework-notice.yml
@@ -1,0 +1,24 @@
+pageTitle: Framework notice
+pageDescription: Used to draw awareness to a particular framework in a specific state, and give suppliers some links
+assetPath: govuk_template/assets/
+grid: column-one-third
+examples:
+  -
+    heading: 'Become a Digital Outcomes and Specialists supplier'
+    subheading: 'Deadline: 14 February 2016 ❤'
+    message: >
+      **Digital Outcomes and Specialists will be open for applications soon.**
+
+
+      You can apply to provide:
+
+        - digital outcomes,
+          eg a discovery phase or an online billing application
+        - digital specialists,
+          eg service managers or developers
+        - user research studios
+        - user research participants
+
+      [Create an account](https://www.digitalmarketplace.service.gov.uk/) to receive an email when Digital Outcomes and Specialists opens.
+
+      [Find out how to apply](https://www.digitalmarketplace.service.gov.uk/)

--- a/pages_builder/pages/index.yml
+++ b/pages_builder/pages/index.yml
@@ -14,6 +14,8 @@ content: >
         <li><a href="breadcrumb.html">Breadcrumb</a></li>
         <li><a href="page-heading.html">Page headings</a></li>
         <li><a href="notification-banner.html">Notification banners</a></li>
+        <li><a href="temporary-message.html">Temporary message</a></li>
+        <li><a href="framework-notice.html">Framework notice</a></li>
         <li><a href="button.html">Buttons</a></li>
         <li><a href="grids.html">Grids</a></li>
         <li><a href="forms/">Forms</a></li>

--- a/pages_builder/requirements.txt
+++ b/pages_builder/requirements.txt
@@ -6,3 +6,6 @@ six==1.8.0
 wsgiref==0.1.2
 Jinja2==2.7.3
 Pygments==2.0.2
+
+git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
+git+https://github.com/alphagov/digitalmarketplace-utils.git@10.6.0#egg=digitalmarketplace-utils==10.6.0

--- a/toolkit/scss/_framework-notice.scss
+++ b/toolkit/scss/_framework-notice.scss
@@ -1,8 +1,5 @@
-@import "_colours.scss";
 @import "_typography.scss";
 @import "_measurements.scss";
-@import "_shims.scss";
-@import "_conditionals.scss";
 
 
 %framework-notice,
@@ -15,10 +12,13 @@
   }
 
   .framework-notice-subheading {
-    margin-bottom: 5px;
+    @include core-16;
+    color: $secondary-text-colour;
+    margin: 0 0 5px 0;
   }
 
   p {
+    margin: 0;
     padding: 0 0 10px 0;
 
     a {

--- a/toolkit/scss/_framework-notice.scss
+++ b/toolkit/scss/_framework-notice.scss
@@ -1,0 +1,37 @@
+@import "_colours.scss";
+@import "_typography.scss";
+@import "_measurements.scss";
+@import "_shims.scss";
+@import "_conditionals.scss";
+
+
+%g-cloud-7-notice,
+.g-cloud-7-notice {
+  margin-top: 45px;
+
+  .g-cloud-7-notice-heading {
+    @include bold-24;
+    margin-bottom: $gutter-half;
+  }
+
+  .g-cloud-7-notice-subheading {
+    margin-bottom: 5px;
+  }
+
+  p {
+    padding: 0 0 10px 0;
+
+    a {
+      text-decoration: underline;
+    }
+  }
+
+  ul {
+    margin: 0;
+    padding: 0 0 10px 20px;
+
+     li {
+       padding-bottom: 5px;
+     }
+  }
+}

--- a/toolkit/scss/_framework-notice.scss
+++ b/toolkit/scss/_framework-notice.scss
@@ -5,16 +5,16 @@
 @import "_conditionals.scss";
 
 
-%g-cloud-7-notice,
-.g-cloud-7-notice {
+%framework-notice,
+.framework-notice {
   margin-top: 45px;
 
-  .g-cloud-7-notice-heading {
+  .framework-notice-heading {
     @include bold-24;
     margin-bottom: $gutter-half;
   }
 
-  .g-cloud-7-notice-subheading {
+  .framework-notice-subheading {
     margin-bottom: 5px;
   }
 

--- a/toolkit/templates/framework-notice.html
+++ b/toolkit/templates/framework-notice.html
@@ -8,6 +8,6 @@
     </p>
   {% endif %}
   {% if message %}
-    {{ message }}
+    {{ message|markdown }}
   {% endif %}
 </aside>

--- a/toolkit/templates/framework-notice.html
+++ b/toolkit/templates/framework-notice.html
@@ -1,9 +1,9 @@
 <aside role="complementary" aria-labelledby="framework-notice-heading" class="framework-notice">
-  <h2 id="framework-notice-heading">
+  <h2 class="framework-notice-heading">
     {{ heading }}
   </h2>
   {% if subheading %}
-    <p class="framework-notice-subheading hint">
+    <p class="framework-notice-subheading">
       {{ subheading }}
     </p>
   {% endif %}

--- a/toolkit/templates/framework-notice.html
+++ b/toolkit/templates/framework-notice.html
@@ -1,0 +1,13 @@
+<aside role="complementary" aria-labelledby="g-cloud-7-notice-heading">
+  <h2 id="g-cloud-7-notice-heading">
+    {{ heading }}
+  </h2>
+  {% if subheading %}
+    <p class="g-cloud-7-notice-subheading hint">
+      {{ subheading }}
+    </p>
+  {% endif %}
+  {% if message %}
+    {{ message }}
+  {% endif %}
+</aside>

--- a/toolkit/templates/framework-notice.html
+++ b/toolkit/templates/framework-notice.html
@@ -1,9 +1,9 @@
-<aside role="complementary" aria-labelledby="g-cloud-7-notice-heading">
-  <h2 id="g-cloud-7-notice-heading">
+<aside role="complementary" aria-labelledby="framework-notice-heading" class="framework-notice">
+  <h2 id="framework-notice-heading">
     {{ heading }}
   </h2>
   {% if subheading %}
-    <p class="g-cloud-7-notice-subheading hint">
+    <p class="framework-notice-subheading hint">
       {{ subheading }}
     </p>
   {% endif %}


### PR DESCRIPTION
There are (at this point) two types of framework notice messages we need:

- The blue one [we currently have](https://www.digitalmarketplace.service.gov.uk/).
![screen shot 2015-10-22 at 11 46 12](https://cloud.githubusercontent.com/assets/2454380/10663341/8fd65b40-78b2-11e5-8500-94dc3434e362.png)

- The more descriptive one that [we're introducing DOS with](http://dm-prototype.herokuapp.com/states/homepage?dos.framework=open).
![screen shot 2015-10-22 at 11 38 40](https://cloud.githubusercontent.com/assets/2454380/10663359/a83472ee-78b2-11e5-9947-1f793ed1791e.png)

The first one [we already have](http://alphagov.github.io/digitalmarketplace-frontend-toolkit/temporary-message.html), and the latter one is added in this pull request. 

To get the flexible formatting we need, I've included a markdown filter in the template, which will be [included in digitalmarketplace-utils](https://github.com/alphagov/digitalmarketplace-utils/blob/master/dmutils/flask_init.py#L48) and subsequently available to all of our apps.  The [`markdown_filter`](https://github.com/alphagov/digitalmarketplace-utils/blob/master/dmutils/filters.py) method to utils also allows us to add it to our jinja environment in `generate_pages.py` so that our pages build. 

Should work everywhere with minimal effort. :smile:

Related to [this story](https://www.pivotaltracker.com/story/show/105005304) on Pivotal.