### PR TITLE
Improve documentation navigation

### DIFF
--- a/pages_builder/assets/scss/index.scss
+++ b/pages_builder/assets/scss/index.scss
@@ -135,8 +135,16 @@ a.version-link {
   padding: 0 0 $gutter*2 0;
 
   li {
-    margin-bottom: 5px;
     list-style: none;
+  }
+
+  a {
+    display: inline-block;
+    margin-bottom: 5px;
+  }
+
+  .index-list {
+    padding: 0 0 0 $gutter-half;
   }
 
 }

--- a/pages_builder/pages/index.yml
+++ b/pages_builder/pages/index.yml
@@ -16,7 +16,35 @@ content: >
         <li><a href="button.html">Buttons</a></li>
         <li><a href="contact-details.html">Contact details</a></li>
         <li><a href="documents.html">Documents</a></li>
-        <li><a href="forms/">Forms</a></li>
+        <li>
+          <a href="forms/">Forms</a>
+          <ul class="index-list">
+            <li>
+              <a href="upload.html">File upload</a>
+            </li>
+            <li>
+              <a href="keyword-search.html">Keyword search</a>
+            </li>
+            <li>
+              <a href="list-entry.html">List entry textbox</a>
+            </li>
+            <li>
+              <a href="option-select.html">Option select</a>
+            </li>
+            <li>
+              <a href="pricing.html">Pricing</a>
+            </li>
+            <li>
+              <a href="selection-buttons.html">Selection buttons</a>
+            </li>
+            <li>
+              <a href="textbox.html">Textboxes</a>
+            </li>
+            <li>
+              <a href="validation.html">Validation</a>
+            </li>
+          </ul>
+        </li>
         <li><a href="framework-notice.html">Framework notice</a></li>
         <li><a href="grids.html">Grids</a></li>
         <li><a href="link-button.html">Link button</a></li>

--- a/pages_builder/pages/index.yml
+++ b/pages_builder/pages/index.yml
@@ -12,22 +12,22 @@ content: >
       <ul class="index-list">
         <li><a href="beta-banner.html">Beta banner</a></li>
         <li><a href="breadcrumb.html">Breadcrumb</a></li>
-        <li><a href="page-heading.html">Page headings</a></li>
-        <li><a href="notification-banner.html">Notification banners</a></li>
-        <li><a href="temporary-message.html">Temporary message</a></li>
-        <li><a href="framework-notice.html">Framework notice</a></li>
+        <li><a href="browse-list.html">Browse list</a></li>
         <li><a href="button.html">Buttons</a></li>
-        <li><a href="grids.html">Grids</a></li>
+        <li><a href="contact-details.html">Contact details</a></li>
+        <li><a href="documents.html">Documents</a></li>
         <li><a href="forms/">Forms</a></li>
-        <li><a href="summary-table.html">Summary tables</a></li>
+        <li><a href="framework-notice.html">Framework notice</a></li>
+        <li><a href="grids.html">Grids</a></li>
+        <li><a href="link-button.html">Link button</a></li>
+        <li><a href="notification-banner.html">Notification banners</a></li>
+        <li><a href="page-heading.html">Page headings</a></li>
+        <li><a href="previous-next-navigation.html">Previous/next navigation</a></li>
         <li><a href="search-results.html">Search result</a></li>
         <li><a href="search-summary.html">Search summary</a></li>
-        <li><a href="documents.html">Documents</a></li>
-        <li><a href="browse-list.html">Browse list</a></li>
         <li><a href="service-id.html">Service ID</a></li>
-        <li><a href="contact-details.html">Contact details</a></li>
-        <li><a href="previous-next-navigation.html">Previous/next navigation</a></li>
-        <li><a href="link-button.html">Link button</a></li>
+        <li><a href="summary-table.html">Summary tables</a></li>
+        <li><a href="temporary-message.html">Temporary message</a></li>
       </ul>
     </div>
   </main>


### PR DESCRIPTION
This pull request:
- sorts the navigation in the documentation alphabetically
- flattens the navigation to add links to form patterns on the homepage

![image](https://cloud.githubusercontent.com/assets/355079/11205256/35951274-8cfe-11e5-8f5a-8fc0126066b3.png)
