### PR TITLE
Preserve key order when parsing YAML

### DIFF
--- a/pages_builder/generate_pages.py
+++ b/pages_builder/generate_pages.py
@@ -7,6 +7,7 @@ import json
 import sys
 from subprocess import call
 from distutils import dir_util
+from collections import OrderedDict
 from template_handler import TemplateHandler
 from asset_compiler import AssetCompiler
 from jinja2 import Environment, FileSystemLoader, Template
@@ -14,6 +15,20 @@ from pygments import highlight
 from pygments.lexers import HtmlLexer, DjangoLexer
 from pygments.formatters import HtmlFormatter
 from dmutils.filters import markdown_filter
+
+
+# preserve key order when parsing YAML – http://stackoverflow.com/a/21048064/147318
+
+def dict_representer(dumper, data):
+    return dumper.represent_dict(data.iteritems())
+
+
+def dict_constructor(loader, node):
+    return OrderedDict(loader.construct_pairs(node))
+
+
+yaml.add_representer(OrderedDict, dict_representer)
+yaml.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, dict_constructor)
 
 
 class Styleguide_publisher(object):


### PR DESCRIPTION
Reasons:
- it makes it easier to cross-reference the code examples and the YAML files and the outputted code examples
- the YAML files have their keys in a logical order, eg `title` comes before `body`; it’s good to keep this in our code examples, and, by extension, the code that gets copied and pasted into our apps

## Before
![image](https://cloud.githubusercontent.com/assets/355079/11205422/728637ca-8cff-11e5-9714-b7b6f7c656d3.png)

## After
![image](https://cloud.githubusercontent.com/assets/355079/11205397/4d5789c2-8cff-11e5-9c93-9f7d543f2cfc.png)
