### PR TITLE
Fix broken links on homepage

### DIFF
--- a/pages_builder/pages/index.yml
+++ b/pages_builder/pages/index.yml
@@ -20,28 +20,28 @@ content: >
           <a href="forms/">Forms</a>
           <ul class="index-list">
             <li>
-              <a href="upload.html">File upload</a>
+              <a href="forms/upload.html">File upload</a>
             </li>
             <li>
-              <a href="keyword-search.html">Keyword search</a>
+              <a href="forms/keyword-search.html">Keyword search</a>
             </li>
             <li>
-              <a href="list-entry.html">List entry textbox</a>
+              <a href="forms/list-entry.html">List entry textbox</a>
             </li>
             <li>
-              <a href="option-select.html">Option select</a>
+              <a href="forms/option-select.html">Option select</a>
             </li>
             <li>
-              <a href="pricing.html">Pricing</a>
+              <a href="forms/pricing.html">Pricing</a>
             </li>
             <li>
-              <a href="selection-buttons.html">Selection buttons</a>
+              <a href="forms/selection-buttons.html">Selection buttons</a>
             </li>
             <li>
-              <a href="textbox.html">Textboxes</a>
+              <a href="forms/textbox.html">Textboxes</a>
             </li>
             <li>
-              <a href="validation.html">Validation</a>
+              <a href="forms/validation.html">Validation</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
When the nested links were added to the homepage in https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/181 their (relative) paths were not updated accordingly.

This commit fixes the paths so the links are not broken.