### PR TITLE
Stop document links with icons from overflowing

### DIFF
--- a/toolkit/scss/_document.scss
+++ b/toolkit/scss/_document.scss
@@ -2,6 +2,7 @@
 @import "_typography.scss";
 @import "_not-ie-conditional.scss";
 @import "_shims.scss";
+@import "_css3.scss";
 
 .document-list {
   margin: 0;
@@ -15,6 +16,7 @@
 %document-link,
 .document-link {
   @include core-19;
+  @include box-sizing(border-box);
   margin: 5px 0;
   padding: 10px 0 10px 0;
   position: relative;


### PR DESCRIPTION
Document links with icons have padding applied to them which pushes them out of their parent containers. This led to a bug on smaller screens where the page layout would be pushed beyond the edge of the screen.
Setting `box-sizing: border-box;` on the link elements resolves this.

***

## Bad
![screen shot 2015-12-18 at 17 16 47](https://cloud.githubusercontent.com/assets/2454380/11902724/da3ca34e-a5ab-11e5-9693-2f1866e02608.png)

## Good
![screen shot 2015-12-18 at 17 15 30](https://cloud.githubusercontent.com/assets/2454380/11902729/e078a29e-a5ab-11e5-982d-d93dbd1d513a.png)
