### PR TITLE
Fix typo in example page

### DIFF
--- a/pages_builder/pages/back-link.yml
+++ b/pages_builder/pages/back-link.yml
@@ -3,4 +3,4 @@ assetPath: ../govuk_template/assets/
 examples:
   -
     url: http://example.com
-    text: Back to catagories
+    text: Back to categories


### PR DESCRIPTION
catagories -> categories

[Seen here](http://alphagov.github.io/digitalmarketplace-frontend-toolkit/back-link.html)