### PR TITLE
Fixes to temporary messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ Usage examples for each pattern are defined in the `./pages_builder/pages`
 folder. They are YAML files which show what parameters you can pass to a
 template. The examples in the documentation are generated from these files.
 
+#### Grids in example pages
+
+Examples can use the grids (see [grids example](http://alphagov.github.io/digitalmarketplace-frontend-toolkit/grids.html)) by setting a `grid` property in this file.
+
+If all the examples in your page sit in the same column, set the grid class you need with the page-level properties (ie on the [textbox example page](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/blob/master/pages_builder/pages/forms/textbox.yml#L3)).
+
+If any of your examples need their own column, set the grid class you need with the example-level properties (ie on the [temporary message example page](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/blob/master/pages_builder/pages/temporary-message.yml#L12)).
+
+If you don't need a grid column, don't set any `grid` properties in your file.
+
 ### Template
 
 Templates are found in the `./toolkit/templates` folder. They are Jinja

--- a/pages_builder/generate_pages.py
+++ b/pages_builder/generate_pages.py
@@ -167,11 +167,18 @@ class Styleguide_publisher(object):
                         example_template = example
                         example_markup = env.from_string(example_template).render({})
 
+                    # set a grid if specified. Example-level grids will overwrite the one for the page
+                    grid = None
+                    if 'grid' in example:
+                        grid = example['grid']
+                    elif 'grid' in partial:
+                        grid = partial['grid']
+              
                     examples.append({
                         "parameters": highlight(example_template, DjangoLexer(), HtmlFormatter(noclasses=True)),
                         "markup": example_markup,
-                        "highlighted_markup": highlight(example_markup, HtmlLexer(), HtmlFormatter(noclasses=True))
-
+                        "highlighted_markup": highlight(example_markup, HtmlLexer(), HtmlFormatter(noclasses=True)),
+                        "grid": grid
                     })
                 partial_data = {
                     "examples": examples,

--- a/pages_builder/generate_pages.py
+++ b/pages_builder/generate_pages.py
@@ -168,11 +168,7 @@ class Styleguide_publisher(object):
                         example_markup = env.from_string(example_template).render({})
 
                     # set a grid if specified. Example-level grids will overwrite the one for the page
-                    grid = None
-                    if 'grid' in example:
-                        grid = example['grid']
-                    elif 'grid' in partial:
-                        grid = partial['grid']
+                    grid = example.get('grid', partial.get('grid'))
               
                     examples.append({
                         "parameters": highlight(example_template, DjangoLexer(), HtmlFormatter(noclasses=True)),

--- a/pages_builder/pages/temporary-message.yml
+++ b/pages_builder/pages/temporary-message.yml
@@ -1,13 +1,14 @@
 pageTitle: Temporary message
 pageDescription: Used to describe the status of a page at a point in a process
 assetPath: govuk_template/assets/
-grid: column-one-half
+grid: column-one-whole
 examples:
   -
     heading: G‑Cloud 7 is closed for applications
     messages:
       - Applications are being reviewed.
       - G‑Cloud 7 services will be available from 23 November 2015.
+    grid: column-one-third
   -
     heading: The G-Cloud 7 application deadline has passed
     messages:
@@ -15,3 +16,4 @@ examples:
       - <a href="#">View your application</a>
   -
     heading: Example without any body copy that is quite long and may wrap onto multiple lines
+    grid: column-two-thirds

--- a/pages_builder/pages/temporary-message.yml
+++ b/pages_builder/pages/temporary-message.yml
@@ -5,15 +5,18 @@ grid: column-one-whole
 examples:
   -
     heading: G‑Cloud 7 is closed for applications
+    headingId: closed-notice
     messages:
       - Applications are being reviewed.
       - G‑Cloud 7 services will be available from 23 November 2015.
     grid: column-one-third
   -
     heading: The G-Cloud 7 application deadline has passed
+    headingId: closed-notice
     messages:
       - No services were submitted because you didn’t mark any as complete.
       - <a href="#">View your application</a>
   -
     heading: Example without any body copy that is quite long and may wrap onto multiple lines
+    headingId: closed-notice
     grid: column-two-thirds

--- a/toolkit/templates/temporary-message.html
+++ b/toolkit/templates/temporary-message.html
@@ -1,5 +1,5 @@
-<aside role="complementary" class="temporary-message{% if not messages %}-without-messages{% endif %}">
-  <h2 class="temporary-message-heading">
+<aside role="complementary" class="temporary-message{% if not messages %}-without-messages{% endif %}"{% if headingId %} aria-labelledby="{{ headingId }}"{% endif %}>
+  <h2 class="temporary-message-heading"{% if headingId %} id="{{ headingId }}"{% endif %}>
     {{ heading }}
   </h2>
   {%- for message in messages %}


### PR DESCRIPTION
Add some ARIA to label the `<aside>` sections (using [this technique from the styleguide](https://github.com/alphagov/styleguides/blob/master/html.md#sectioned-content)).

This includes some changes to the toolkit to allow pattern instances to each exist in their own grid column.