### PR TITLE
Fix issue with new grids setting

### DIFF
--- a/pages_builder/generate_pages.py
+++ b/pages_builder/generate_pages.py
@@ -160,15 +160,15 @@ class Styleguide_publisher(object):
                 template = env.get_template(template_file)
                 examples = []
                 for index, example in enumerate(partial["examples"]):
+                    grid = partial.get('grid')
                     if isinstance(example, dict):
                         example_template = self.parameters_example(template_subfolder, template_name, example)
                         example_markup = template.render(example)
+                        # set a grid if specified. Example-level grids will overwrite the one for the page
+                        grid = example.get('grid', partial.get('grid'))
                     else:
                         example_template = example
                         example_markup = env.from_string(example_template).render({})
-
-                    # set a grid if specified. Example-level grids will overwrite the one for the page
-                    grid = example.get('grid', partial.get('grid'))
               
                     examples.append({
                         "parameters": highlight(example_template, DjangoLexer(), HtmlFormatter(noclasses=True)),


### PR DESCRIPTION
Some pages have example data which is a string while most are dictionaries. The code that checked
for a grid being set per-example assumed they were dictionaries so was breaking.