### PR TITLE
Add button attribute

### DIFF
--- a/toolkit/javascripts/option-select.js
+++ b/toolkit/javascripts/option-select.js
@@ -63,6 +63,7 @@
     // Create button and replace the preexisting html with the button.
     var $button = $('<button>');
     $button.addClass('js-container-head');
+    $button.attr('type', 'button');
     $button.attr('aria-expanded', this.isClosed());
     $button.attr('aria-controls', this.$optionSelect.find('.options-container').attr('id'));
     $button.html(jsContainerHeadHTML);


### PR DESCRIPTION
Add button attribute to button element to fix searchbox bug in buyer frontend where pressing
enter on textbox trigger synthetic mouselick event on nearest button in the form.  Adding type button
to the button element overrides default the button default type of submit within the form.