### PR TITLE
Fix Makefile when user is not in a virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,17 @@
 SHELL := /bin/bash
+VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$VIRTUAL_ENV)
 
 virtualenv:
-	[ -z $$VIRTUAL_ENV ] && virtualenv venv || true
+	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && virtualenv venv || true
 
 requirements: virtualenv
-	pip install -r pages_builder/requirements.txt
+	${VIRTUALENV_ROOT}/bin/pip install -r pages_builder/requirements.txt
 
 generate_pages: requirements
-	python pages_builder/generate_pages.py
+	${VIRTUALENV_ROOT}/bin/python pages_builder/generate_pages.py
 
 serve_pages: generate_pages
-	cd pages && python -m SimpleHTTPServer
+	cd pages && ${VIRTUALENV_ROOT}/bin/python -m SimpleHTTPServer
 
 watch_for_changes: generate_pages
-	python pages_builder/watch_for_changes.py
+	${VIRTUALENV_ROOT}/bin/python pages_builder/watch_for_changes.py


### PR DESCRIPTION
We need to use absolute paths to executables that need to be used from
the virtual environment to work for the case when the user is not
already in a virtual environment.