### PR TITLE
Split <h2>s out from <p>s in instruction lists

### DIFF
--- a/toolkit/templates/instruction-list.html
+++ b/toolkit/templates/instruction-list.html
@@ -5,11 +5,13 @@
           divider
         {% endif %}">
           {% if item.body %}
-            <p class="instruction-list-item-body">
-              {% if verbose %}<h2>{{ item.body }}</h2>
-              {% else %}{{ item.body }}
-              {% endif %}
-            </p>
+            {% if verbose %}
+              <h2 class="instruction-list-item-body">{{ item.body }}</h2>
+            {% else %}
+              <p class="instruction-list-item-body">
+              {{ item.body }}
+              </p>
+            {% endif %}
           {% endif %}
         {% if item.sublist_collection %}
           {% for collection in item.sublist_collection %}


### PR DESCRIPTION
While wrapping the `<h2>`s in instruction lists in `<p>`
tags is a valid use of the tags, in verbose mode the 
`<p>` tag doesn't seem to add much and the CSS 
supports just having the `<h2>` on it's own so I'd like
to split it out.

### HTML parsing peculiarity

I've also noted that having a wrapping paragraph can
cause problems with the HTML parser.

It seems that when parsing the content in the `<p>` tag 
it splits it into **flow content** (the `<h2>`) and **phrasing
content** (the rest) and splits the **phrasing content**
into `<p>` tags.

I noticed this in chrome devtools:

![p_tag_parsing_issue](https://cloud.githubusercontent.com/assets/87140/14145829/378b35ba-f68d-11e5-877f-d3faacf710dc.png)

I think it's parsing it using this algorithm in the spec:

https://www.w3.org/TR/html5/dom.html#paragraph