### PR TITLE
Minor refinements to question templates

### DIFF
--- a/toolkit/scss/forms/_validation.scss
+++ b/toolkit/scss/forms/_validation.scss
@@ -53,7 +53,7 @@
 }
 
 .validation-message {
-  display: block;
+  @include inline-block();
   @include core-19;
   font-weight: bold;
   color: $red;

--- a/toolkit/scss/shared_scss/_dmspeak.scss
+++ b/toolkit/scss/shared_scss/_dmspeak.scss
@@ -10,8 +10,7 @@
 }
 
 %markdown-description {
-   @include core-19;
-   padding-bottom: 10px;
+  @include core-19;
 
   p {
     margin: 0;


### PR DESCRIPTION
## 1. Remove bottom padding from question_advice and hint fields

A padding-bottom of 10px was being added to markdown formatted
text which we don't really need because there's a padding-bottom
of 10px added to all paragraphs.

Removing the padding-bottom makes questions with both question_advice
and a hint look neater.

#### --> before 
![screen shot 2016-04-22 at 17 57 03](https://cloud.githubusercontent.com/assets/2454380/14749805/84065efe-08b9-11e6-8b34-4d4fd873986a.png)

#### --> after
![screen shot 2016-04-22 at 17 56 13](https://cloud.githubusercontent.com/assets/2454380/14749816/8a73f85a-08b9-11e6-81c6-bfdd121eb8d3.png)

***

## 2. Preserve margins on validation messages

We were losing vertical margins on `.validation-message`s because the parent container wasn't expanding to account for them. [Learn more about block formatting context (BFC).](http://colinaarts.com/articles/the-magic-of-overflow-hidden/)  <sub>disclaimer: not that interesting</sub>

#### --> before
![screen shot 2016-04-22 at 17 47 59](https://cloud.githubusercontent.com/assets/2454380/14749897/fd078f12-08b9-11e6-92ac-d18a92f492c2.png)

#### --> after
![screen shot 2016-04-22 at 17 48 30](https://cloud.githubusercontent.com/assets/2454380/14749891/f4d083ee-08b9-11e6-878d-6d420e56738e.png)
