### PR TITLE
Add temporary message variant for main pages

### DIFF
--- a/pages_builder/pages/temporary-message.yml
+++ b/pages_builder/pages/temporary-message.yml
@@ -20,3 +20,11 @@ examples:
     heading: Example without any body copy that is quite long and may wrap onto multiple lines
     headingId: closed-notice
     grid: column-two-thirds
+  -
+    heading: G‑Cloud  is open for applications
+    main: True
+    headingId: closed-notice
+    messages:
+      - Example of variant used for main page already containing dark blue banner.
+      - G‑Cloud 8 services will be available from 23 November 2015.
+    grid: column-one-third

--- a/toolkit/scss/_temporary-message.scss
+++ b/toolkit/scss/_temporary-message.scss
@@ -17,6 +17,13 @@
   margin-bottom: $gutter;
 }
 
+.temporary-message-main {
+  @extend %temporary-message;
+  background: $light-blue-25;
+  @include core-19;
+  color: $black;
+}
+
 .temporary-message-without-messages {
   @extend %temporary-message-section;
   padding-bottom: 5px;
@@ -27,6 +34,11 @@
   margin: 0 0 10px 0;
 }
 
+.temporary-message-heading-main {
+  @include bold-19;
+  margin: 0 0 10px 0;
+}
+
 .temporary-message-message {
 
   @include core-16;
@@ -34,6 +46,18 @@
 
   a {
     color: $white;
+    text-decoration: underline;
+  }
+
+}
+
+.temporary-message-message-main {
+
+  @include core-19;
+  margin: 0 0 5px 0;
+
+  a {
+    color: $black;
     text-decoration: underline;
   }
 

--- a/toolkit/templates/temporary-message.html
+++ b/toolkit/templates/temporary-message.html
@@ -1,9 +1,9 @@
-<div class="temporary-message{% if not messages %}-without-messages{% endif %}">
-  <h3 class="temporary-message-heading">
+<div class="temporary-message{% if not messages %}-without-messages{% endif %}{% if main %}-main{% endif %}">
+  <h3 class="temporary-message-heading{% if main %}-main{% endif %}">
     {{ heading }}
   </h3>
   {%- for message in messages %}
-  <p class="temporary-message-message">
+  <p class="temporary-message-message{% if main %}-main{% endif %}">
     {{ message|safe }}
   </p>
   {%- endfor %}


### PR DESCRIPTION
Add temporary message variant for main pages.

<img width="454" alt="screen shot 2016-04-26 at 17 50 29" src="https://cloud.githubusercontent.com/assets/11633362/14826804/76321c70-0bd7-11e6-85da-eabb685f9a87.png">