### PR TITLE
Add _reset.scss to toolkit

### DIFF
--- a/toolkit/scss/shared_scss/_lists.scss
+++ b/toolkit/scss/shared_scss/_lists.scss
@@ -1,3 +1,4 @@
+@import "shared_scss/_reset.scss";
 @import "_measurements.scss";
 @import "_conditionals.scss";
 @import "_typography.scss";
@@ -14,17 +15,6 @@
   list-style-type: disc;
   padding-left: 20px;
   @include list-spacing($list-margin-top: 5px, $list-item-margin-bottom: 5px);
-}
-
-/* TODO: Remove once _reset.scss is migrated */
-body {
-  @include core-19;
-}
-
-ul,
-ol {
-  list-style-type: none;
-  padding: 0;
 }
 
 .list-bullet {

--- a/toolkit/scss/shared_scss/_reset.scss
+++ b/toolkit/scss/shared_scss/_reset.scss
@@ -1,0 +1,112 @@
+@import "typography";
+
+html,
+body,
+div,
+span,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+main,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+}
+
+main {
+  display: block;
+}
+
+ol,
+ul {
+  list-style: none;
+}
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+body {
+  @include core-19;
+}
+
+@include media(tablet) {
+
+  legend {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
All of our frontend apps have reset files, of which almost all of the CSS is identical.

`_reset.scss` in the
- [buyer app](https://github.com/alphagov/digitalmarketplace-buyer-frontend/blob/61c4a9be31f1a8564f670ec8821e2f22cccf9b29/app/assets/scss/_reset.scss)
- [supplier app](https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/9c35949cb5dd302125ce41662ea2383a77c5a6f2/app/assets/scss/_reset.scss)
- [admin app](https://github.com/alphagov/digitalmarketplace-admin-frontend/blob/5a4cabf8ee0364a51e897717068fd76e3af82707/app/assets/scss/_reset.scss)

Using the [`_forms.scss`](https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/0cf570f2528b0e94cb691a72d3258d460353ff08/app/assets/scss/_reset.scss) from the supplier app because it's the completest one.

This means I can remove a bit of styling from the `_lists.scss` file and import the reset instead.