### PR TITLE
[#118469059] Bump up pricing breakpoint even further

### DIFF
--- a/toolkit/scss/forms/_pricing.scss
+++ b/toolkit/scss/forms/_pricing.scss
@@ -3,7 +3,7 @@
 @import "_shims.scss";
 @import "_typography.scss";
 
-@include media($min-width: 950px) {
+@include media($min-width: 959px) {
   .column-two-thirds .pricing {
     margin-right: -50%;
   }
@@ -27,7 +27,7 @@
       margin-left: 0;
       margin-top: $gutter-half;
 
-      @include media($min-width: 950px) {
+      @include media($min-width: 959px) {
         min-height: 105px;
         width: auto;
         margin-left: 10px;
@@ -75,7 +75,7 @@
     margin: 0;
     z-index: 10;
 
-    @include media($min-width: 950px) {
+    @include media($min-width: 959px) {
       position: absolute;
     }
 
@@ -95,7 +95,7 @@
     width: 98%; // Chrome tries to chop the sides off when you make the font bigger
     font-size: 19px;
 
-    @include media($min-width: 950px) {
+    @include media($min-width: 959px) {
       margin-left: 0;
     }
 
@@ -123,7 +123,7 @@
     padding-bottom: 12px;
     display: none;
 
-    @include media($min-width: 950px) {
+    @include media($min-width: 959px) {
       display: block;
     }
   }


### PR DESCRIPTION
So, it turns out that our breakpoint works perfectly until it doesn't.

In our case, enforcing scroll bars on browser windows divorced the page width from the browser width, which dropped the last field down a line for very specific browser widths.

Bumping the breakpoint up 9 pixels to mitigate the problem as much as possible without going over `960px` (which is the max-width we use for our central column).

No problems if scroll bars aren't present, and very unlikely to be a problem otherwise.

[>> Bug on Tracker](https://www.pivotaltracker.com/story/show/118469059)

***

## adding a scroll bar breaks the layout (for a very specific browser width)
![price](https://cloud.githubusercontent.com/assets/2454380/15825568/2c13ebec-2bfc-11e6-90e3-3053358b1d46.gif)

