### PR TITLE
Use string concatenation instead of format method

### DIFF
--- a/toolkit/templates/forms/list-entry.html
+++ b/toolkit/templates/forms/list-entry.html
@@ -1,8 +1,8 @@
 {% if hint %}
-  {% set answer_advice_id="input-{}-answer-advice".format(id) %}
+  {% set answer_advice_id="input-" + id + "-answer-advice" %}
 {% endif %}
 {% if question_advice %}
-  {% set question_advice_id="input-{}-question-advice".format(id) %}
+  {% set question_advice_id="input-" + id + "-question-advice" %}
 {% endif %}
 
 {% if not values %}

--- a/toolkit/templates/forms/pricing.html
+++ b/toolkit/templates/forms/pricing.html
@@ -7,10 +7,10 @@
 {%- endmacro %}
 
 {% if hint %}
-  {% set answer_advice_id="input-{}-answer-advice".format(name) %}
+  {% set answer_advice_id="input-" + name + "-answer-advice" %}
 {% endif %}
 {% if question_advice %}
-  {% set question_advice_id="input-{}-question-advice".format(name) %}
+  {% set question_advice_id="input-" + name + "-question-advice" %}
 {% endif %}
 
 {% if error %}

--- a/toolkit/templates/forms/selection-buttons.html
+++ b/toolkit/templates/forms/selection-buttons.html
@@ -1,8 +1,8 @@
 {% if hint %}
-  {% set answer_advice_id="input-{}-answer-advice".format(name) %}
+  {% set answer_advice_id="input-" + name + "-answer-advice" %}
 {% endif %}
 {% if question_advice %}
-  {% set question_advice_id="input-{}-question-advice".format(name) %}
+  {% set question_advice_id="input-" + name + "-question-advice" %}
 {% endif %}
 
 {% if error %}

--- a/toolkit/templates/forms/textbox.html
+++ b/toolkit/templates/forms/textbox.html
@@ -1,8 +1,8 @@
 {% if hint %}
-  {% set answer_advice_id="input-{}-answer-advice".format(name) %}
+  {% set answer_advice_id="input-" + name + "-answer-advice" %}
 {% endif %}
 {% if question_advice %}
-  {% set question_advice_id="input-{}-question-advice".format(name) %}
+  {% set question_advice_id="input-" + name + "-question-advice" %}
 {% endif %}
 
 {% if error %}

--- a/toolkit/templates/forms/upload.html
+++ b/toolkit/templates/forms/upload.html
@@ -1,8 +1,8 @@
 {% if hint %}
-  {% set answer_advice_id="input-{}-answer-advice".format(name) %}
+  {% set answer_advice_id="input-" + name + "-answer-advice" %}
 {% endif %}
 {% if question_advice %}
-  {% set question_advice_id="input-{}-question-advice".format(name) %}
+  {% set question_advice_id="input-" + name + "-question-advice" %}
 {% endif %}
 
 {% if error %}

--- a/toolkit/templates/summary-table.html
+++ b/toolkit/templates/summary-table.html
@@ -272,7 +272,7 @@
   {% call field() -%}
     {% if value -%}
       {% for question in value %}
-        {% set macro = '{}_content'.format(question.type) %}
+        {% set macro = question.type + '_content' %}
         <div class="multiquestion">
           <p>{{ question.name if question.name else question.question }}</p>
           <div>{{ content[macro](question.value, question.assurance) }}</div>


### PR DESCRIPTION
We use our macros with the nunjucks templating
language, written for JavaScript. Use of the
`format` method is causing an error in this
context because it is not supported in JavaScript.

This switches use of `format` out for string
concatenation with the `+` operator, something
supported by both Python and JavaScript.