### PR TITLE
Add a npm install build step to docs generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,10 @@ virtualenv:
 requirements: virtualenv
 	${VIRTUALENV_ROOT}/bin/pip install -r pages_builder/requirements.txt
 
-generate_pages: requirements
+npm_install:
+	npm install
+
+generate_pages: requirements npm_install
 	${VIRTUALENV_ROOT}/bin/python pages_builder/generate_pages.py
 
 serve_pages: generate_pages

--- a/pages_builder/push_to_github_pages.sh
+++ b/pages_builder/push_to_github_pages.sh
@@ -41,7 +41,7 @@ echo "Generating pages"
 echo "--------------------------------------------------------------------------------"
 rm -rf ./*
 cd ..
-python ./pages_builder/generate_pages.py
+make generate_pages
 echo "--------------------------------------------------------------------------------"
 echo "Commiting changes to generated pages"
 echo "--------------------------------------------------------------------------------"


### PR DESCRIPTION
The part of the script that makes the JS for the docs site was rewritten to copy all the `node_modules` JS across in this commit: https://github.com/alphagov/digitalmarketplace-frontend-toolkit/commit/9e32356eb296f798674b6c8c4ee117389da07a60#diff-76a5ddb47815102dec7ecd599047c69bR227

Only problem is there's no `npm install` step to the current docs generation (and so no `node_modules` folder) which meant the script was breaking. This adds it so should fix it.