### PR TITLE
Make module loader recallable

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,21 +6,24 @@ var environment;
 var repoRoot = __dirname + '/';
 
 gulp.task('test', function () {
-  var manifest = require(repoRoot + 'spec/javascripts/manifest.js').manifest;
+  var manifest = require(repoRoot + 'spec/javascripts/manifest.js').manifest,
+      fixPaths;
 
-  manifest.support = manifest.support.map(function (val) {
-    return val.replace(/^(\.\.\/)*/, function (match) {
-      if (match === '../../../') {
-        return '';
-      }
-      else {
-        return 'spec/javascripts/support/'
-      }
+  fixPaths = function (val) {
+    val = val.replace(/^(\.\.\/)*/, function (match) {
+      var steps = match.split('/'),
+          root = ['spec', 'javascripts', 'support'];
+
+      // remove the end match which is always blank
+      steps.pop();
+      replacement = root.slice(0, root.length - steps.length);
+      return (replacement.length) ?  replacement.join('/') + '/' : '';
     });
-  });
-  manifest.test = manifest.test.map(function (val) {
-    return val.replace(/^\.\.\//, 'spec/javascripts/');
-  });
+    return val;
+  };
+
+  manifest.support = manifest.support.map(fixPaths);
+  manifest.test = manifest.test.map(fixPaths);
 
   return gulp.src(manifest.test)
     .pipe(jasmine({

--- a/spec/javascripts/manifest.js
+++ b/spec/javascripts/manifest.js
@@ -4,12 +4,15 @@ var manifest = {
     'vendor/jquery.js',
     'vendor/hogan.js',
     '../../../node_modules/govuk_frontend_toolkit/javascripts/vendor/polyfills/bind.js',
+    '../unit/ModuleLoaderSetup.js',
     '../../../toolkit/javascripts/list-entry.js',
-    '../../../toolkit/javascripts/word-counter.js'
+    '../../../toolkit/javascripts/word-counter.js',
+    '../../../toolkit/javascripts/module-loader.js'
   ],
   test : [
     '../unit/WordCountSpec.js',
-    '../unit/ListEntrySpec.js'
+    '../unit/ListEntrySpec.js',
+    '../unit/ModuleLoaderSpec.js'
   ]
 };
 

--- a/spec/javascripts/unit/ModuleLoaderSetup.js
+++ b/spec/javascripts/unit/ModuleLoaderSetup.js
@@ -1,0 +1,17 @@
+// Block used to set up checks for the tests run in ModuleLoaderSpec
+
+// Intentionally global variable
+GOVUK = {
+  'GDM': {
+    'testObjectModuleLoaded' : false,
+    'testFunctionModuleLoaded' : false,
+    'testFunctionModule': function () {
+      this.testFunctionModuleLoaded = true;  
+    },
+    'testObjectModule': {
+      'init': function () {
+        GOVUK.GDM.testObjectModuleLoaded = true;  
+      }
+    }
+  }
+};

--- a/spec/javascripts/unit/ModuleLoaderSpec.js
+++ b/spec/javascripts/unit/ModuleLoaderSpec.js
@@ -1,0 +1,33 @@
+describe("ModuleLoader", function () {
+  describe("When module-loader.js is loaded", function () {
+    // The following checks are set up ModuleLoaderSetup.js, before the moduleloader is first called
+    // GOVUK.GDM.testFunctionModuleLoaded is set to false, turned to true when GOVUK.GDM.testFunctionModule is called
+    // GOVUK.GDM.testObjectModuleLoaded is set to false, turned to true when GOVUK.GDM.testObjectModule is called
+
+    it("Loads function modules", function () {
+      expect(GOVUK.GDM.testFunctionModuleLoaded).toBe(true);
+    });
+
+    it("Loads object modules", function () {
+      expect(GOVUK.GDM.testObjectModuleLoaded).toBe(true);
+    });
+  });
+
+  describe("When loadModulesInNamespace is called after load", function () {
+    it("loads modules not part of the namespace on load", function () {
+      GOVUK.GDM.testFunctionModule2 = function () {};
+      GOVUK.GDM.testObjectModule2 = {
+        "init": function () {}
+      };
+
+      spyOn(GOVUK.GDM, "testFunctionModule2");
+      spyOn(GOVUK.GDM.testObjectModule2, "init");
+
+      GOVUK.GDM.moduleLoader.loadModulesInNamespace();
+
+      expect(GOVUK.GDM.testFunctionModule2).toHaveBeenCalled();
+      expect(GOVUK.GDM.testObjectModule2.init).toHaveBeenCalled();
+    });
+  });
+});
+

--- a/toolkit/javascripts/module-loader.js
+++ b/toolkit/javascripts/module-loader.js
@@ -2,50 +2,107 @@
 
   "use strict";
 
-  var module;
-
-  if(typeof console === 'undefined') {
-    console = {
-      log: function () {},
-      time: function () {},
-      timeEnd: function () {}
-    };
-  }
-
-  if (
-    (GDM.debug = !window.location.href.match(/gov.uk/) && !window.jasmine)
-  ) {
-    console.log(
-      "%cDebug mode %cON",
-      "color:#550; background:yellow; font-size: 11pt",
-      "color:yellow; background: #550;font-size:11pt"
-    );
-    console.time("Modules loaded");
-  }
-
-  // Initialise our modules
-  for (module in GDM) {
-
-    if (GDM.debug && module !== "debug") {
-      console.log(
-        "%cLoading module %c" + module,
-        "color:#6a6; background:#dfd; font-size: 11pt",
-        "color:#dfd; background:green; font-size: 11pt"
-      );
+  var ModuleLoader = function () {
+    if (typeof GDM.debug !== 'undefined') {
+      GDM.debug = !window.location.href.match(/gov.uk/) && !window.jasmine;
     }
+    this.cache = [];
+    this.console.init();
+  };
 
-    if ("function" === typeof GDM[module].init) {
+  // Wrapper for calls to global console method
+  ModuleLoader.prototype.console = {
+    init: function () {
+
+      // Older browers don't have window.console to stub it if so
+      if(typeof console === 'undefined') {
+        console = {
+          log: function () {},
+          time: function () {},
+          timeEnd: function () {}
+        };
+      }
+
+      if (GDM.debug) {
+        console.log(
+          "%cDebug mode %cON",
+          "color:#550; background:yellow; font-size: 11pt",
+          "color:yellow; background: #550;font-size:11pt"
+        );
+        console.time("Modules loaded");
+      }
+
+    },
+    log: function (module) {
+
+      if (GDM.debug && module !== "debug") {
+        console.log(
+          "%cLoading module %c" + module,
+          "color:#6a6; background:#dfd; font-size: 11pt",
+          "color:#dfd; background:green; font-size: 11pt"
+        );
+      }
+
+    }
+  };
+
+  // Load the a module from the namespace, if it fits our criteria
+  ModuleLoader.prototype.loadModule = function (module, namespace) {
+
+    if ("function" === typeof namespace[module].init) {
       // If a module has an init() method then we want that to be called here
-      GDM[module].init();
-    } else if ("function" === typeof GDM[module]) {
+      namespace[module].init();
+    } else if ("function" === typeof namespace[module]) {
       // If a module doesn't have an interface then call it directly
-      GDM[module]();
+      namespace[module]();
     }
 
-  }
+  };
+
+  // Check if a module has loaded already
+  ModuleLoader.prototype.moduleIsLoaded = function (module, namespace) {
+
+    var namespaceCached = (typeof this.cache[namespace] !== 'undefined'),
+        moduleLoaded = $.inArray(module, this.cache[namespace]) > -1;
+
+    return namespaceCached && moduleLoaded;
+
+  };
+
+  // cache the module against its namespace
+  ModuleLoader.prototype.addToCache = function (module, namespace) {
+
+    if (typeof this.cache[namespace] === 'undefined') {
+      this.cache[namespace] = [];
+    }
+    this.cache[namespace].push(module);
+
+  };
+  ModuleLoader.prototype.loadModulesFromNamespace = function (namespace) {
+
+    var module;
+
+    // Initialise all modules in namespace
+    for (module in namespace) {
+
+      // Load any modules not already loaded
+      if (!this.moduleIsLoaded(module, namespace)) {
+        this.console.log(module);
+        this.loadModule(module)
+        this.addToCache(module, namespace);
+      }
+
+    }
+    if (GDM.debug) console.timeEnd("Modules loaded");
+
+  };
 
   GOVUK.GDM = GDM;
 
-  if (GDM.debug) console.timeEnd("Modules loaded");
+  // Store an instance of ModuleLoader on GDM
+  GOVUK.GDM.moduleLoader = new ModuleLoader();
+
+  // Load all modules already added to GOVUK.GDM
+  GOVUK.GDM.moduleLoader.loadModulesFromNamespace(GDM);
 
 }).apply(this, [GOVUK||{}, GOVUK.GDM||{}]);

--- a/toolkit/javascripts/module-loader.js
+++ b/toolkit/javascripts/module-loader.js
@@ -1,11 +1,12 @@
-(function(GOVUK, GDM) {
+(function(root, namespace) {
 
   "use strict";
 
-  var ModuleLoader = function () {
-    if (typeof GDM.debug !== 'undefined') {
-      GDM.debug = !window.location.href.match(/gov.uk/) && !window.jasmine;
+  var ModuleLoader = function (namespace) {
+    if (typeof namespace.debug !== 'undefined') {
+      namespace.debug = !window.location.href.match(/gov.uk/) && !window.jasmine;
     }
+    this.namespace = namespace;
     this.cache = [];
     this.console.init();
   };
@@ -15,28 +16,28 @@
     init: function () {
 
       // Older browers don't have window.console to stub it if so
-      if(typeof console === 'undefined') {
-        console = {
+      if(typeof root.console === 'undefined') {
+        root.console = {
           log: function () {},
           time: function () {},
           timeEnd: function () {}
         };
       }
 
-      if (GDM.debug) {
-        console.log(
+      if (namespace.debug) {
+        root.console.log(
           "%cDebug mode %cON",
           "color:#550; background:yellow; font-size: 11pt",
           "color:yellow; background: #550;font-size:11pt"
         );
-        console.time("Modules loaded");
+        root.console.time("Modules loaded");
       }
 
     },
     log: function (module) {
 
-      if (GDM.debug && module !== "debug") {
-        console.log(
+      if (namespace.debug && module !== "debug") {
+        root.console.log(
           "%cLoading module %c" + module,
           "color:#6a6; background:#dfd; font-size: 11pt",
           "color:#dfd; background:green; font-size: 11pt"
@@ -46,63 +47,49 @@
     }
   };
 
-  // Load the a module from the namespace, if it fits our criteria
-  ModuleLoader.prototype.loadModule = function (module, namespace) {
+  // Load the a module, if it fits our criteria
+  ModuleLoader.prototype.loadModule = function (module) {
 
-    if ("function" === typeof namespace[module].init) {
+    if ("function" === typeof this.namespace[module].init) {
       // If a module has an init() method then we want that to be called here
-      namespace[module].init();
-    } else if ("function" === typeof namespace[module]) {
+      this.namespace[module].init();
+    } else if ("function" === typeof this.namespace[module]) {
       // If a module doesn't have an interface then call it directly
-      namespace[module]();
+      this.namespace[module]();
     }
 
   };
 
   // Check if a module has loaded already
-  ModuleLoader.prototype.moduleIsLoaded = function (module, namespace) {
+  ModuleLoader.prototype.moduleIsLoaded = function (module) {
 
-    var namespaceCached = (typeof this.cache[namespace] !== 'undefined'),
-        moduleLoaded = $.inArray(module, this.cache[namespace]) > -1;
-
-    return namespaceCached && moduleLoaded;
+    return $.inArray(module, this.cache) > -1;
 
   };
 
-  // cache the module against its namespace
-  ModuleLoader.prototype.addToCache = function (module, namespace) {
-
-    if (typeof this.cache[namespace] === 'undefined') {
-      this.cache[namespace] = [];
-    }
-    this.cache[namespace].push(module);
-
-  };
-  ModuleLoader.prototype.loadModulesFromNamespace = function (namespace) {
+  ModuleLoader.prototype.loadModulesInNamespace = function () {
 
     var module;
 
     // Initialise all modules in namespace
-    for (module in namespace) {
+    for (module in this.namespace) {
 
       // Load any modules not already loaded
-      if (!this.moduleIsLoaded(module, namespace)) {
+      if (!this.moduleIsLoaded(module)) {
         this.console.log(module);
         this.loadModule(module)
-        this.addToCache(module, namespace);
+        this.cache.push(module);
       }
 
     }
-    if (GDM.debug) console.timeEnd("Modules loaded");
+    if (namespace.debug) console.timeEnd("Modules loaded");
 
   };
 
-  GOVUK.GDM = GDM;
-
   // Store an instance of ModuleLoader on GDM
-  GOVUK.GDM.moduleLoader = new ModuleLoader();
+  namespace.moduleLoader = new ModuleLoader(namespace);
 
   // Load all modules already added to GOVUK.GDM
-  GOVUK.GDM.moduleLoader.loadModulesFromNamespace(GDM);
+  namespace.moduleLoader.loadModulesInNamespace();
 
-}).apply(this, [GOVUK||{}, GOVUK.GDM||{}]);
+}).apply(this, [window, GOVUK.GDM]);


### PR DESCRIPTION
The module loader usually sits at the end of each app's `application.js` and initialises all modules added to the `GOVUK.GDM` namespace up until that point:

The order of `application.js` is roughly:

1. load all base libraries, ie analytics and jquery
2. load all modules from this toolkit and attach them to the `GOVUK.GDM` namespace
3. run the `module-loader.js` code which looks for any modules in `GOVUK.GDM` and initialises them

This means if you want to load any more JavaScript files into the page you can't run them because they load after `application.js`, at which point `module-loader.js` has run.

This pull request refactors `module-loader.js` so you can run it more than once without re-initialising any modules already called.

The use case for this was some code @risicle was writing to make the stats we have as part of the admin app public. In this case, that view needed the [d3](https://d3js.org/) library but it was the only view that did. That code never made it to production but I think there's some value to this and the new form doesn't break any existing uses.