### PR TITLE
[WIP] New example page with lots of child questions

### DIFF
--- a/pages_builder/pages/forms/all.yml
+++ b/pages_builder/pages/forms/all.yml
@@ -1,0 +1,98 @@
+pageTitle: All fields
+assetPath: ../govuk_template/assets/
+grid: column-two-thirds
+bodyEnd: >
+  <script type="text/javascript" src="../public/javascripts/govuk_frontend_toolkit/vendor/polyfills/bind.js"></script>
+  <script type="text/javascript" src="../public/javascripts/govuk_frontend_toolkit/govuk/selection-buttons.js"></script>
+  <script type="text/javascript" src="../public/javascripts/show-hide-content.js"></script>
+  <script type="text/javascript" src="../public/javascripts/vendor/hogan-3.0.2.min.js"></script>
+  <script type="text/javascript" src="../public/javascripts/list-entry.js"></script>
+  <script type="text/javascript" src="../public/javascripts/word-counter.js"></script>
+examples:
+  - |
+    <form>
+
+    {% import "forms/_all.html" as _ %}
+
+    {%
+      set _types = {
+        "001": "text",
+        "002": "textbox",
+        "003": "text",
+        "004": "radio",
+        "005": "text",
+        "006": "checkbox",
+        "007": "text",
+        "008": "boolean",
+        "009": "text",
+        "010": "radio_description",
+        "011": "text",
+        "012": "checkbox_hint_underneath",
+        "013": "text",
+        "014": "list_entry",
+        "015": "text",
+        "016": "date_entry",
+        "017": "text"
+      }
+    %}
+
+    {%
+      with
+      followup = {True: _types.keys()|sort},
+      name = "000",
+      question = "Can you do this thing?",
+      value = true,
+      type = "boolean"
+    %}
+      {% include "forms/selection-buttons.html" %}
+    {% endwith %}
+
+    {% for num, type in _types.items()|sort %}
+      {{ _.macros[type](num) }}
+    {% endfor %}
+
+    </form>
+
+  - |
+    <form>
+
+    {% import "forms/_all.html" as _ %}
+
+    {%
+      set _types = {
+        "101": "text",
+        "102": "textbox",
+        "103": "text",
+        "104": "radio",
+        "105": "text",
+        "106": "checkbox",
+        "107": "text",
+        "108": "boolean",
+        "109": "text",
+        "110": "radio_description",
+        "111": "text",
+        "112": "checkbox_hint_underneath",
+        "113": "text",
+        "114": "list_entry",
+        "115": "text",
+        "116": "date_entry",
+        "117": "text"
+      }
+    %}
+
+    {%
+      with
+      followup = {True: _types.keys()|sort},
+      name = "100",
+      question = "Uh oh, it looks like you can't do this thing.",
+      value = true,
+      type = "boolean"
+    %}
+      {% include "forms/selection-buttons.html" %}
+    {% endwith %}
+
+    {% for num, type in _types.items()|sort %}
+      {{ _.macros[type](num, "From 12th January 1973 it will no longer be legal") }}
+    {% endfor %}
+
+    </form>

--- a/toolkit/templates/forms/_all.html
+++ b/toolkit/templates/forms/_all.html
@@ -1,0 +1,142 @@
+{% macro _text(_name, _error=None) %}
+  {%
+    with
+    question = "Text",
+    name = _name,
+    error = _error,
+    hidden = true
+  %}
+    {% include "forms/textbox.html" %}
+  {% endwith %}
+{% endmacro %}
+
+{% macro _textbox(_name, _error=None) %}
+  {%
+    with
+    large = true,
+    max_length_in_words = 10,
+    question = "Textbox wordcount",
+    name = _name,
+    error = _error,
+    hidden = true
+  %}
+    {% include "forms/textbox.html" %}
+  {% endwith %}
+{% endmacro %}
+
+{% macro _radio(_name, _error=None) %}
+  {%
+    with
+    question = "Radio",
+    type = "radio",
+    name = _name,
+    options = [{"label": "Snooper Force"}, {"label": "Sponge Avengers"}],
+    error = _error,
+    hidden = true
+  %}
+    {% include "forms/selection-buttons.html" %}
+  {% endwith %}
+{% endmacro %}
+
+{% macro _radio_description(_name, _error=None) %}
+  {%
+    with
+    question = "Radio description",
+    type = "radio",
+    name = _name,
+    options = [
+      {
+        "label": "Voices of the 1%",
+        "description": "The investment banker said £100m was a lot of money – but 'not a ridiculous amount of money'. He told the researcher he was 'fairly confident' that a driven and passionate individual could 'start from zero and get to £100m within 20 years'."
+      }
+    ],
+    error = _error,
+    hidden = true
+  %}
+    {% include "forms/selection-buttons.html" %}
+  {% endwith %}
+{% endmacro %}
+
+{% macro _boolean(_name, _error=None) %}
+  {%
+    with
+    name = _name,
+    question = "Boolean",
+    value = true,
+    type = "boolean",
+    error = _error,
+    hidden = true
+  %}
+    {% include "forms/selection-buttons.html" %}
+  {% endwith %}
+{% endmacro %}
+
+{% macro _checkbox(_name, _error=None) %}
+  {%
+    with
+    question = "Checkbox",
+    type = "checkbox",
+    name = _name,
+    options = [{"label": "Snooper Force"}, {"label": "Sponge Avengers"}],
+    error = _error,
+    hidden = true
+  %}
+    {% include "forms/selection-buttons.html" %}
+  {% endwith %}
+{% endmacro %}
+
+{% macro _checkbox_hint_underneath(_name, _error=None) %}
+  {%
+    with
+    name = _name,
+    hint = "He would really like a private jet but can’t afford one.",
+    hint_underneath = true,
+    question = "Checkbox hint underneath",
+    type = "checkbox",
+    options = [{"label": "Snooper Force"}, {"label": "Sponge Avengers"}],
+    error = _error,
+    hidden = true
+  %}
+    {% include "forms/selection-buttons.html" %}
+  {% endwith %}
+{% endmacro %}
+
+{% macro _list_entry(_name, _error=None) %}
+  {%
+    with
+    question = "List new entry",
+    id = _name,
+    number_of_items=10,
+    error = _error,
+    hidden = true
+  %}
+    {% include "forms/list-entry.html" %}
+  {% endwith %}
+{% endmacro %}
+
+{% macro _date_entry(_name, _error=None) %}
+  {%
+    with
+    question = "Date entry",
+    name = _name,
+    data={},
+    error = _error,
+    hidden = true
+  %}
+    {% include "forms/date.html" %}
+  {% endwith %}
+{% endmacro %}
+
+{%
+  set macros = {
+     'text': _text,
+     'textbox': _textbox,
+     'radio': _radio,
+     'checkbox': _checkbox,
+     'boolean': _boolean,
+     'radio_description': _radio_description,
+     'checkbox_hint_underneath': _checkbox_hint_underneath,
+     'list_entry': _list_entry,
+     'date_entry': _date_entry
+  }
+%}


### PR DESCRIPTION
One of our problems around borders for child questions has been that we just don't have a view of very many of them.

There are far more combinations of child/dependent questions in the submissions process than we actually have in the frontend toolkit in the 'combinations' page, yet it's the combinations page that we're normally checking when we're doing CSS changes.

Essentially, we're visually testing a very small subset of the total universe of possibilities and so we're going to get things slip through.

This code creates a new page on which we can very rapidly create loads of child fields one after another.

It's pretty prototype-y code (and the new page isn't included in any of the menus), but it's helpful for seeing the effect of general CSS changes to child questions.

***

This is what it looks like if you boot up the toolkit and run: http://localhost:8000/forms/all.html

![screen shot 2017-05-05 at 11 51 28-fullpage](https://cloud.githubusercontent.com/assets/2454380/25742835/3d37d4f4-3189-11e7-9262-b6e819b6a7cd.png)
