### PR TITLE
Remove `visuallyhidden`. Use `visually-hidden` instead.

### DIFF
--- a/toolkit/javascripts/list-entry.js
+++ b/toolkit/javascripts/list-entry.js
@@ -32,7 +32,7 @@
   ListEntry.prototype.entryTemplate = Hogan.compile(
     '<div class="list-entry">' +
       '<label for="{{{id}}}" class="text-box-number-label">' +
-        '<span class="visuallyhidden">{{listItemName}} number </span>{{number}}.' +
+        '<span class="visually-hidden">{{listItemName}} number </span>{{number}}.' +
       '</label>' +
       '<input' +
         ' name="{{name}}"' +
@@ -42,7 +42,7 @@
       '/>' +
       '{{#button}}' +
         '<button type="button" class="button-secondary list-entry-remove">' +
-          'Remove<span class="visuallyhidden"> {{listItemName}} number {{number}}</span>' +
+          'Remove<span class="visually-hidden"> {{listItemName}} number {{number}}</span>' +
         '</button>' +
       '{{/button}}' +
     '</div>'

--- a/toolkit/scss/forms/_checkbox-tree.scss
+++ b/toolkit/scss/forms/_checkbox-tree.scss
@@ -6,7 +6,7 @@
 @include fake-full-width('.checkbox-tree');
 
 fieldset.checkbox-tree__inputs > legend {
-  @extend %visuallyhidden;
+  @extend %visually-hidden;
 }
 
 .checkbox-tree__counter {
@@ -82,7 +82,7 @@ fieldset.checkbox-tree__inputs > legend {
     }
 
     legend {
-      @extend %visuallyhidden;
+      @extend %visually-hidden;
     }
 
     .categories-heading {

--- a/toolkit/scss/forms/_pricing.scss
+++ b/toolkit/scss/forms/_pricing.scss
@@ -127,8 +127,3 @@
   }
 
 }
-
-.visually-hidden {
-  position: absolute;
-  left: -999em;
-}

--- a/toolkit/scss/forms/_questions.scss
+++ b/toolkit/scss/forms/_questions.scss
@@ -1,7 +1,7 @@
 @import "colours";
 @import "typography";
 @import "shared_scss/_dmspeak.scss";
-@import "shared_placeholders/_visuallyhidden.scss";
+@import "shared_placeholders/_visually-hidden.scss";
 
 // The following placeholders must be present in your main stylesheet:
 // - shared_placeholders/_placeholders.scss
@@ -109,6 +109,6 @@
 
   /* Visual users have the h1 as the label, so hide it for them */
   form [class^="question-heading"] {
-    @extend %visuallyhidden;
+    @extend %visually-hidden;
   }
 }

--- a/toolkit/scss/shared_placeholders/_visually-hidden.scss
+++ b/toolkit/scss/shared_placeholders/_visually-hidden.scss
@@ -1,4 +1,4 @@
-%visuallyhidden {
+%visually-hidden {
   position: absolute;
   left: -9999em;
 }

--- a/toolkit/templates/forms/list-entry.html
+++ b/toolkit/templates/forms/list-entry.html
@@ -60,7 +60,7 @@
         {% for index in range(0, number_of_items) %}
           <div class="list-entry">
             <label for="input-{{ id }}-{{ index }}" class="text-box-number-label">
-              <span class="visuallyhidden">{{item_name}} number </span>{{ index + 1 }}.
+              <span class="visually-hidden">{{item_name}} number </span>{{ index + 1 }}.
             </label>
             <input
               type="text"

--- a/toolkit/templates/instruction-list.html
+++ b/toolkit/templates/instruction-list.html
@@ -72,7 +72,7 @@
         {% if item.important %}
         <div class="notice">
           <i class="icon icon-important">
-            <span class="visuallyhidden">Warning</span>
+            <span class="visually-hidden">Warning</span>
           </i>
           <strong class="bold-small">
             {{ item.important }}

--- a/toolkit/templates/summary-table.html
+++ b/toolkit/templates/summary-table.html
@@ -23,7 +23,7 @@
 
 {% macro mapping_table(caption='', field_headings='', field_headings_visible=True, caption_visible=False, no_bottom_border=False, row_bold_borders=False, text_large=False) -%}
   <table class="summary-item-body{% if no_bottom_border %}-no-bottom-border{% endif %}{% if row_bold_borders %}-row-bold-borders{% endif %}{% if text_large %}-text-large{% endif %}">
-    <caption {% if not caption_visible %}class="visuallyhidden"{% endif %}>
+    <caption {% if not caption_visible %}class="visually-hidden"{% endif %}>
       {% if caption_visible %}<strong>{% endif %}{{ caption }}{% if caption_visible %}</strong>{% endif %}
     </caption>
     <thead class="summary-item-field-headings{% if field_headings_visible %}-visible{% endif %}">
@@ -33,7 +33,7 @@
             {% if field_headings_visible %}
               {{ field_heading }}
             {% else %}
-              <span class="visuallyhidden">{{ field_heading }}</span>
+              <span class="visually-hidden">{{ field_heading }}</span>
             {% endif %}
           </th>
         {% endfor %}
@@ -119,7 +119,7 @@
 {% macro edit_link(label=None, link=None, hidden_text='') -%}
   {% call field(action=True) -%}
     {% if label and link -%}
-      <a href="{{ link }}">{{ label }}{% if hidden_text %}<span class="visuallyhidden"> {{ hidden_text }}</span>{% endif %}</a>
+      <a href="{{ link }}">{{ label }}{% if hidden_text %}<span class="visually-hidden"> {{ hidden_text }}</span>{% endif %}</a>
     {%- endif %}
   {%- endcall %}
 {%- endmacro %}
@@ -128,7 +128,7 @@
 {% macro remove_link(label=None, link=None, hidden_text='') -%}
   {% call field(action=True) -%}
     {% if label and link -%}
-      <a href="{{ link }}" class="summary-item-remove-link">{{ label }}{% if hidden_text %}<span class="visuallyhidden"> {{ hidden_text }}</span>{% endif %}</a>
+      <a href="{{ link }}" class="summary-item-remove-link">{{ label }}{% if hidden_text %}<span class="visually-hidden"> {{ hidden_text }}</span>{% endif %}</a>
     {%- endif %}
   {%- endcall %}
 {%- endmacro %}


### PR DESCRIPTION
This change is super trivial.

Technically, both `visuallyhidden` and `visually-hidden` will work
as classnames to hide things in the visual interface (both are
included in govuk_template), but here in _our_ frontend toolkit,
we should be consistent.

`visually-hidden` is more readable and closer in convention to
our other classnames in, so I've removed the other ones.

I've also removed a `visually-hidden` CSS rule that was just a
straight copy from something we already get from govuk_template.

No visual changes.