### PR TITLE
Run the toolkit with Python 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$VIRTUAL_ENV)
 
 virtualenv:
-	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && virtualenv venv || true
+	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && virtualenv -p python3 venv || true
 
 requirements: virtualenv
 	${VIRTUALENV_ROOT}/bin/pip install -r pages_builder/requirements.txt

--- a/pages_builder/asset_compiler.py
+++ b/pages_builder/asset_compiler.py
@@ -28,9 +28,9 @@ class AssetCompiler(object):
         dest_path_abs = os.path.join(self.sass_dest_root, file)
         dest_path_abs = self.__change_extension_to(dest_path_abs, "css")
         result = sass.compile(**sass_options)
-        print "    " + sass_options["filename"]
-        print "▸ " + dest_path_abs
-        print ""
+        print("    " + sass_options["filename"])
+        print("▸ " + dest_path_abs)
+        print("")
         with codecs.open(dest_path_abs, "w+", "utf-8") as file:
             file.write(result)
 
@@ -39,12 +39,12 @@ class AssetCompiler(object):
             for dir in dirs:
                 dest_dir = os.path.join(self.sass_dest_root, dir)
                 if os.path.isdir(dest_dir) is False:
-                    print "★ Creating " + dest_dir
+                    print("★ Creating " + dest_dir)
                     os.mkdir(dest_dir)
                 else:
-                    print "✔ Found " + dest_dir
+                    print("✔ Found " + dest_dir)
 
-            print ""
+            print("")
 
             for file in files:
                 if self.__get_filename_parts(file)["extension"] == ".scss":

--- a/pages_builder/generate_pages.py
+++ b/pages_builder/generate_pages.py
@@ -233,7 +233,7 @@ class Styleguide_publisher(object):
         page_render = pystache.render(self.template_view, partial)
         print("\n  " + input_file)
         print("▸ " + output_file)
-        open(output_file, "w+").write(page_render.encode('utf-8'))
+        open(output_file, "wb+").write(page_render.encode('utf-8'))
 
     def compile_assets(self, folder):
         print("\nCOMPILING ASSETS from " + folder + "\n")

--- a/pages_builder/generate_pages.py
+++ b/pages_builder/generate_pages.py
@@ -19,7 +19,7 @@ from pygments.formatters import HtmlFormatter
 # preserve key order when parsing YAML – http://stackoverflow.com/a/21048064/147318
 
 def dict_representer(dumper, data):
-    return dumper.represent_dict(data.iteritems())
+    return dumper.represent_dict(data.items())
 
 
 def dict_constructor(loader, node):
@@ -119,7 +119,7 @@ class Styleguide_publisher(object):
 
         presented_parameters = {
             key: json.dumps(value, indent=4)
-            for key, value in parameters.iteritems()
+            for key, value in parameters.items()
         }
 
         return parameters_template.render(

--- a/pages_builder/generate_pages.py
+++ b/pages_builder/generate_pages.py
@@ -82,20 +82,20 @@ class Styleguide_publisher(object):
 
     def render_pages(self):
 
-        print "\nCREATING PAGES from " + self.pages_dirname + " \n"
+        print("\nCREATING PAGES from " + self.pages_dirname + " \n")
 
         if os.path.isdir(self.output_dirname) is False:
-            print "★ Creating " + self.output_dirname
+            print("★ Creating " + self.output_dirname)
             os.mkdir(self.output_dirname)
 
         for root, dirs, files in os.walk(self.pages_dirname):
             for dir in dirs:
                 output_dir = self.__get_output_dir(dir)
                 if os.path.isdir(output_dir) is False:
-                    print "★ Creating " + output_dir
+                    print("★ Creating " + output_dir)
                     os.mkdir(output_dir)
                 else:
-                    print "✔ Found " + output_dir
+                    print("✔ Found " + output_dir)
 
             for file in files:
                 if self.__is_yaml(file):
@@ -231,17 +231,17 @@ class Styleguide_publisher(object):
             }
         )
         page_render = pystache.render(self.template_view, partial)
-        print "\n  " + input_file
-        print "▸ " + output_file
+        print("\n  " + input_file)
+        print("▸ " + output_file)
         open(output_file, "w+").write(page_render.encode('utf-8'))
 
     def compile_assets(self, folder):
-        print "\nCOMPILING ASSETS from " + folder + "\n"
+        print("\nCOMPILING ASSETS from " + folder + "\n")
         self.asset_compiler.compile(folder)
 
     def copy_javascripts(self):
-        print "\nCOPYING JAVASCRIPTSn"
-        print "Created files:\n\n"
+        print("\nCOPYING JAVASCRIPTSn")
+        print("Created files:\n\n")
         copied_scripts = []
         copied_scripts += dir_util.copy_tree("toolkit/javascripts", "pages/public/javascripts")
         copied_scripts += dir_util.copy_tree(
@@ -251,13 +251,13 @@ class Styleguide_publisher(object):
             "node_modules/govuk_frontend_toolkit/javascripts",
             "pages/public/javascripts/govuk_frontend_toolkit/"
         )
-        print "\n".join(copied_scripts)
-        print "★ Done"
+        print("\n".join(copied_scripts))
+        print("★ Done")
 
     def copy_images(self):
-        print "\nCOPYING IMAGES\n"
+        print("\nCOPYING IMAGES\n")
         dir_util.copy_tree("toolkit/images", "pages/public/images")
-        print "★ Done"
+        print("★ Done")
 
     def __get_output_dir(self, directory):
         return os.path.join(self.output_dirname, directory)

--- a/pages_builder/parameters_template.html
+++ b/pages_builder/parameters_template.html
@@ -1,7 +1,7 @@
 {{ '
 {%
   with' }}
-{%- for key, value in parameters.iteritems() %}
+{%- for key, value in parameters.items() %}
   {{ key }} = {{ value }}{% if not loop.last %},{% endif %}
 {%- endfor %}
 {{ '%}' }}

--- a/pages_builder/requirements.txt
+++ b/pages_builder/requirements.txt
@@ -3,7 +3,6 @@ libsass==0.11.1
 pystache==0.5.4
 requests==2.5.0
 six==1.8.0
-wsgiref==0.1.2
 Jinja2==2.7.3
 Pygments==2.0.2
 watchdog==0.8.3

--- a/pages_builder/template_handler.py
+++ b/pages_builder/template_handler.py
@@ -33,7 +33,7 @@ class TemplateHandler(object):
     print("Downloading the latest govuk_template (" + self.latest_release + ")")
     temp_tarball_filename = os.path.join(temp_dir, self.latest_release_filename)
     response = requests.get(self.latest_release_url)
-    open(temp_tarball_filename, "w").write(response.content)
+    open(temp_tarball_filename, "wb").write(response.content)
 
   def extract_archive(self, temp_dir):
    print("Extracting govuk_template " + self.latest_release + " from tarball")

--- a/pages_builder/template_handler.py
+++ b/pages_builder/template_handler.py
@@ -30,13 +30,13 @@ class TemplateHandler(object):
     return self.template_dir
 
   def download_archive(self, temp_dir):
-    print "Downloading the latest govuk_template (" + self.latest_release + ")"
+    print("Downloading the latest govuk_template (" + self.latest_release + ")")
     temp_tarball_filename = os.path.join(temp_dir, self.latest_release_filename)
     response = requests.get(self.latest_release_url)
     open(temp_tarball_filename, "w").write(response.content)
 
   def extract_archive(self, temp_dir):
-   print "Extracting govuk_template " + self.latest_release + " from tarball"
+   print("Extracting govuk_template " + self.latest_release + " from tarball")
    tarball = os.path.join(temp_dir, self.latest_release_filename)
    tar_obj = tarfile.open(tarball, "r:gz")
    tar_obj.extractall(temp_dir)
@@ -52,7 +52,7 @@ class TemplateHandler(object):
    template_dir = os.path.join(self.repo_root, self.template_dir)
    template_release_dir = os.path.join(temp_dir, self.latest_release_dirname)
 
-   print "Saving the release to the 'govuk_template' dir"
+   print("Saving the release to the 'govuk_template' dir")
    shutil.copytree(template_release_dir, template_dir)
 
   def clean_up(self, temp_dir):

--- a/server.py
+++ b/server.py
@@ -1,7 +1,6 @@
 import sys
-from SimpleHTTPServer import SimpleHTTPRequestHandler
-from SocketServer import ThreadingMixIn
-from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
+from http.server import SimpleHTTPRequestHandler, HTTPServer, BaseHTTPRequestHandler
+from socketserver import ThreadingMixIn
 
 
 PORT = 8000


### PR DESCRIPTION
I thought I had a fix to add to the toolkit but turns out it's OK.

In the meantime I got it running locally under Python 3, and this was the minimal set of changes I had to make so that `make serve_pages` and `make watch_for_changes` both work OK.

This new version will no longer work with Python 2, but I think that's what we want these days?