### PR TITLE
Fix version fetching in pages builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "Front end application for Digital Marketplace suppliers",
-  "version": "28.12.0",
+  "version": "28.12.1",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/pages_builder/generate_pages.py
+++ b/pages_builder/generate_pages.py
@@ -62,9 +62,8 @@ class Styleguide_publisher(object):
         self.copy_images()
 
     def get_version(self):
-        return open(
-            os.path.join(self.repo_root, "VERSION.txt")
-        ).read().rstrip()
+        data = json.load(open(os.path.join(self.repo_root, "package.json")))
+        return data["version"]
 
     def get_template_folder(self):
         template_handler = TemplateHandler()
@@ -140,7 +139,7 @@ class Styleguide_publisher(object):
         partial = yaml.safe_load(open(input_file, "r").read())
         url_root = os.getenv("ROOT_DIRECTORY") or ""
         # for index pages, we want to render variables in the content
-        # - add version number from VERSION.txt to the main index page
+        # - add version number from package.json to the main index page
         # - add urlRoot to the nested 'index.html' pages
         if 'index.html' in output_file:
             partial['content'] = pystache.render(


### PR DESCRIPTION
Yesterday I changed versioning system for frontend-toolkit and did not realise that pages builder was still trying to pull version from now non-existent `VERSION.txt`. 

This pull request reroutes a method that looks for the version, so it searches `package.json` instead.

I checked and it works on my local machine.