### PR TITLE
Import track external link js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "Front end application for Digital Marketplace suppliers",
-  "version": "28.13.0",
+  "version": "28.13.1",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/toolkit/javascripts/analytics/_init.js
+++ b/toolkit/javascripts/analytics/_init.js
@@ -7,6 +7,7 @@
 //= include _register.js
 //= include _pageViews.js
 //= include _virtualPageViews.js
+//= include _trackExternalLinks.js
 
 (function(root) {
   "use strict";


### PR DESCRIPTION
The js file wasn't being imported and so not compiled in analytics.js.
This was kicking an error on the frontend.