### PR TITLE
Removes additional margin on notifications banner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
-  "description": "Front end application for Digital Marketplace suppliers",
-  "version": "28.13.1",
+  "description": "A toolkit for design patterns used across Digital Marketplace projects",
+  "version": "28.13.2",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/toolkit/scss/_notification-banners.scss
+++ b/toolkit/scss/_notification-banners.scss
@@ -27,10 +27,6 @@
   }
 }
 
-.flash-message-container%banner {
-  margin-bottom: 40px;
-}
-
 %banner-destructive {
   @extend %banner;
   color: $red;


### PR DESCRIPTION
This was only required in one place (index page of buyer frontend)

Ticket: https://trello.com/c/z1RNJnQy/18-layout-tweaks-on-saved-search-task-list-page

Related PR: https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/745