### PR TITLE
Upgrade deps due to security warnings

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -54,9 +54,7 @@ gulp.task(
   )
 );
 
-gulp.task('copy',
-  ['copy:govuk_frontend_toolkit', 'copy:govuk-elements-sass']
-);
+gulp.task('copy', gulp.series('copy:govuk_frontend_toolkit', 'copy:govuk-elements-sass'));
 
 // Test
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -77,7 +77,7 @@ gulp.task('test', function () {
 
   return gulp.src(manifest.test)
     .pipe(jasmine({
-      'jasmine': '2.0',
+      'jasmineVersion': '2.0',
       'integration': true,
       'abortOnFail': true,
       'vendor': manifest.support

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "govuk_frontend_toolkit": "5.0.3",
     "govuk-elements-sass": "3.0.3",
     "gulp": "4.0.0",
-    "gulp-jasmine-phantom": "3.0.0",
-    "jasmine-core": "2.6.4"
+    "gulp-jasmine-phantom": "3.0.0"
   },
   "scripts": {
     "clean": "./node_modules/gulp/bin/gulp.js clean",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "del": "^2.2.2",
     "govuk_frontend_toolkit": "5.0.3",
     "govuk-elements-sass": "3.0.3",
-    "gulp": "3.8.11",
+    "gulp": "4.0.0",
     "gulp-jasmine-phantom": "3.0.0",
     "jasmine-core": "2.6.4"
   },


### PR DESCRIPTION
This is the result of me looking at the Snyk vulnerability report and having a go at following its advice.
It's advice was split into three parts. Updating versions, applying Snyk patches, and doing nothing. This PR only addresses the first part, updating versions.

It's reduced the number of reported issues from Snyk from 6 to 4. Unfortunately it only fixed the two low priority issues. The next step would be to allow Snyk to apply its patches to fix issues that can't be remedied via version bumping.

I'm unsure as to the use of this PR but thought it worth opening to see what people's feelings are. 

### Upgrade gulp to version 4.0.0  …
Snyk is reporting that we should update gulp to v4.0.0

### Remove dependency on `jasmin-core`  …
Jasmin is brought in by `gulp-jasmin-phantom`. We don't need to specify
it here.

### Fix `jasmineVerison` in `gulp-jasmine-phantom` options  …
`gulp-phantom-jasmine` takes an object of options with initialized. One
of these in the version of Jasmine to use (it supports v2.0 - v2.4). To
set this, the key used should be `jasmineVersion`, not `jasmine`. If
`gulp-phantom-jasmine` doesn't find this key, it defaults to 2.0, so
this update doesn't actually make a functional difference.