### PR TITLE
Move buyer app templates into frontend-toolkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "28.13.2",
+  "version": "28.13.3",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "28.13.3",
+  "version": "28.14.0",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/toolkit/templates/layouts/_base_page.html
+++ b/toolkit/templates/layouts/_base_page.html
@@ -1,0 +1,53 @@
+{% extends "govuk/govuk_template.html" %}
+
+{% block head %} 
+  {% block custom_meta %}{% include "toolkit/custom-dimensions.html" %}{% endblock %}
+  {% include "toolkit/layouts/_stylesheets.html" %}
+  {% include "toolkit/layouts/_site_verification.html" %}
+{% endblock %}
+
+{% block cookie_message %}
+  {% include "toolkit/layouts/_cookie_message.html" %}
+{% endblock %}
+
+{% block header_class %}with-proposition{% endblock %}
+
+{% block inside_header %}
+  {% include "toolkit/inside-header.html" %}
+{% endblock %}
+
+{% block proposition_header %}
+  {% include "toolkit/proposition-header.html" %}
+{% endblock %}
+
+{% block content %}
+    {% block top_header %}
+    {% endblock %}
+  {% block breadcrumb %}{% endblock %}
+  <div id="wrapper">
+    <main id="content" role="main">
+      {% include "toolkit/flash_messages.html" %}
+      {% block main_content %}
+      {% endblock %}
+    </main>
+  </div>
+{% include "toolkit/report-a-problem.html" %}
+{% endblock %}
+
+{% block footer_top %}
+  {% include "toolkit/layouts/_footer_categories.html" %}
+{% endblock %}
+
+{% block footer_support_links %}
+    <h2 class="visuallyhidden">Support links</h2>
+    <ul>
+        <li><a href="/terms-and-conditions" class="terms-and-conditions">Terms and conditions</a></li>
+        <li><a href="/cookies">Cookies</a></li>
+        <li>Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a></li>
+    </ul>
+{% endblock %}
+
+{% block body_end %}
+  {% include "toolkit/layouts/_javascripts.html" %}
+  {% block page_scripts %}{% endblock %}
+{% endblock %}

--- a/toolkit/templates/layouts/_cookie_message.html
+++ b/toolkit/templates/layouts/_cookie_message.html
@@ -1,0 +1,2 @@
+<p>GOV.UK uses cookies to make the site simpler. <a href="/cookies">Find out more about cookies</a></p>
+

--- a/toolkit/templates/layouts/_footer_categories.html
+++ b/toolkit/templates/layouts/_footer_categories.html
@@ -1,0 +1,66 @@
+<div class="footer-categories">
+  <div class="footer-about">
+    <h2>
+      Contact
+    </h2>
+    <ul>
+      <li>
+        <a href="{{ url_for('external.help') }}">Digital Marketplace help</a>
+      </li>
+    </ul>
+  </div>
+  <div class="footer-buyers">
+    <h2>
+      About the Digital Marketplace
+    </h2>
+    <ul>
+      <li>
+        <a href="https://www.gov.uk/government/collections/digital-marketplace-buyers-and-suppliers-information">Digital Marketplace information</a>
+      </li>
+      <li>
+        <a href="https://digitalmarketplace.blog.gov.uk">Digital Marketplace blog</a>
+      </li>
+      <li>
+        <a href="https://www.gov.uk/guidance/the-g-cloud-framework-on-the-digital-marketplace">G-Cloud framework</a>
+      </li>
+      <li>
+        <a href="{{ url_for('external.suppliers_list_by_prefix') }}">G-Cloud supplier A–Z</a>
+      </li>
+      <li>
+        <a href="https://www.gov.uk/guidance/the-crown-hosting-data-centres-framework-on-the-digital-marketplace">Crown Hosting framework</a>
+      </li>
+      <li>
+        <a href="https://www.gov.uk/government/organisations/crown-commercial-service">Crown Commercial Service</a>
+      </li>
+    </ul>
+  </div>
+  <div class="footer-suppliers">
+    <h2>
+        Guidance
+    </h2>
+    <ul>
+      <li>
+        <a href="https://www.gov.uk/guidance/digital-marketplace-buyers-guide">Digital Marketplace buyers’ guide</a>
+      </li>
+      <li>
+        <a href="https://www.gov.uk/guidance/digital-marketplace-suppliers-guide">Digital Marketplace suppliers’ guide</a>
+      </li>
+      <li>
+        <a href="https://www.gov.uk/guidance/g-cloud-buyers-guide">G-Cloud buyers’ guide</a>
+      </li>
+      <li>
+        <a href="https://www.gov.uk/guidance/g-cloud-suppliers-guide">G-Cloud suppliers’ guide</a>
+      </li>
+      <li>
+        <a href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-buyers-guide">Digital Outcomes and Specialists buyers’ guide</a>
+      </li>
+      <li>
+        <a href="https://www.gov.uk/guidance/how-to-hire-user-research-labs-on-the-digital-marketplace">Digital Outcomes and Specialists user research labs buyers’ guide</a>
+      </li>
+      <li>
+        <a href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide">Digital Outcomes and Specialists suppliers’ guide</a>
+      </li>
+    </ul>
+  </div>
+  <hr/>
+</div>

--- a/toolkit/templates/layouts/_javascripts.html
+++ b/toolkit/templates/layouts/_javascripts.html
@@ -1,0 +1,1 @@
+<script type="text/javascript" src="{{ asset_fingerprinter.get_url('javascripts/application.js') }}"></script>

--- a/toolkit/templates/layouts/_site_verification.html
+++ b/toolkit/templates/layouts/_site_verification.html
@@ -1,0 +1,3 @@
+{% if config.GOOGLE_SITE_VERIFICATION %}
+    <meta name="google-site-verification" content="{{ config.GOOGLE_SITE_VERIFICATION }}" />
+{% endif %}

--- a/toolkit/templates/layouts/_stylesheets.html
+++ b/toolkit/templates/layouts/_stylesheets.html
@@ -1,0 +1,9 @@
+<!--[if gt IE 8]><!-->
+  <link type="text/css" rel="stylesheet" media="screen" href="{{ asset_fingerprinter.get_url('stylesheets/application.css') }}" />
+<!--<![endif]-->
+<!--[if IE 7]>
+  <link type="text/css" rel="stylesheet" media="screen" href="{{ asset_fingerprinter.get_url('stylesheets/application-ie7.css') }}" />
+<![endif]-->
+<!--[if IE 8]>
+  <link type="text/css" rel="stylesheet" media="screen" href="{{ asset_fingerprinter.get_url('stylesheets/application-ie8.css') }}" />
+<![endif]-->


### PR DESCRIPTION
Epic: https://trello.com/c/5pZdW4Cb/122-centralise-frontend-header-footer-templates

* Buyer app templates such as `_base_page.html` move into the frontend-toolkit.
* Organise the frontend-toolkit the frontend toolkit so it's easy to distinguish between its existing set of 'components' and templates like this that we are just including or extending from other DM apps;
* Move any Javascript that's easy to move but we can mostly come back to refactoring of that in another ticket.

Ticket: https://trello.com/c/lzYdOQ4C/56-move-buyer-app-templates-into-frontend-toolkit