### PR TITLE
Instrument GA tracking to capture clicks made on external links

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "28.14.0",
+  "version": "28.14.1",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/toolkit/javascripts/analytics/_trackExternalLinks.js
+++ b/toolkit/javascripts/analytics/_trackExternalLinks.js
@@ -12,7 +12,10 @@
         var category = 'external-link-all';
         var action = $target.text();
         var label = $target.attr('href');
-        GOVUK.GDM.analytics.events.sendEvent(category, action, label);
+        GOVUK.analytics.trackEvent(category, action, {
+          'label': label,
+          'transport': 'beacon'
+        });
       });
     }
   };


### PR DESCRIPTION
Removes wrapper function in favour of a direct call to GOVUK function. This is required as wrapper function is not available in all apps.

====
A lot of GA tracking comes 'out of the box' but a notable exception is tracking to capture clicks on external links. Additional code is required in order to capture these.

Currently, we are tracking some external links on the DM site (those that were specifically required for previous mission work).

The proposal is to have all external links tracked automatically across the whole site, similar to how GOV.UK have done.

The advantage of doing this is that we have key data available straight away at the start of mission teams rather than having to prioritise the work, use up dev resource and then wait for enough data to populate before being able to carry out analysis.

---> includes making sure all links on the homepage are tracked, so we can measure which links are used the most and least.

https://trello.com/c/GU1raroG/57-instrument-ga-tracking-to-capture-clicks-made-on-external-links