### PR TITLE
Add privacy notice link to footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "28.14.1",
+  "version": "28.15.0",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/toolkit/templates/layouts/_base_page.html
+++ b/toolkit/templates/layouts/_base_page.html
@@ -43,6 +43,7 @@
     <ul>
         <li><a href="/terms-and-conditions" class="terms-and-conditions">Terms and conditions</a></li>
         <li><a href="/cookies">Cookies</a></li>
+        <li><a href="/privacy-notice">Privacy notice</a></li>
         <li>Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a></li>
     </ul>
 {% endblock %}


### PR DESCRIPTION
Ticket:
https://trello.com/c/KJvWWDaD/191-add-privacy-notice-as-new-page-with-link-in-dm-footer

Requires:
https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/756