### PR TITLE
Update validation masthead pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 Records breaking changes from major version bumps
 
+## 29.0.0
+
+PR: [439](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/439)
+
+### What changed
+The validation masthead in `toolkit.forms.validation` is now an h2 rather than an h1. This may break associated unit and functional tests. Manual review will be needed here.
+
+The pattern now expects to reference a variable called `errors`, so you will need to pass all form errors into the templating engine as `errors=errors` or `errors=get_errors_from_wtform(form)` when calling `render_template()`.
+
+A new utility function has been added to `dmutils.forms` called `get_errors_from_wtform`. Wherever we use WTForms to do form validation, we should use this method to collect errors from the form and pass them into the Jinja templating engine with `render_template(..., errors=errors, ...)`.
+
+Old code sample 1 (template):
+```Jinja2
+  {% if errors %}
+    {% with errors = errors.values() %}
+      {% include 'toolkit/forms/validation.html' %}
+    {% endwith %}
+  {% endif %}
+```
+
+New code sample 1 (template):
+```Jinja2
+{% include 'toolkit/forms/validation.html' %}
+```
+
+Old code sample 2 (python):
+```python
+form_errors = [
+    {'question': form[field].label.text, 'input_name': form[field].name} for field in form.errors.keys()
+]
+return render_template('blah.html', form_errors=form_errors)
+```
+
+New code sample 2 (python):
+```python
+from dmutils.forms import get_errors_from_wtform
+return render_template('blah.html', errors=get_errors_from_wtform(form))
+```
+
 ## 28.0.0
 
 PR: [#397](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/397)

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "28.15.0",
+  "version": "29.0.0",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,
   "engine": "node == 6.10.3",
   "dependencies": {
     "del": "^2.2.2",
-    "govuk_frontend_toolkit": "5.0.3",
     "govuk-elements-sass": "3.0.3",
+    "govuk_frontend_toolkit": "5.0.3",
     "gulp": "3.8.11",
     "gulp-jasmine-phantom": "3.0.0",
     "jasmine-core": "2.6.4"

--- a/toolkit/templates/forms/validation.html
+++ b/toolkit/templates/forms/validation.html
@@ -1,13 +1,15 @@
+{% if errors %}
 <div class="validation-masthead" aria-labelledby="validation-masthead-heading" aria-role="group" tabindex="-1">
-  <h1 class="validation-masthead-heading" id="validation-masthead-heading">
+  <h2 class="validation-masthead-heading" id="validation-masthead-heading">
     {{ lede or "There was a problem with your answer to:"}}
-  </h1>
+  </h2>
   {% if description %}
     <p class="validation-masthead-description">
       {{ description }}
     </p>
   {% endif %}
-  {% for error in errors %}
+  {% for error in errors.values() %}
     <a href="#{{ error.input_name }}" class="validation-masthead-link">{{ error.question }}</a>
   {% endfor %}
 </div>
+{% endif %}

--- a/toolkit/templates/layouts/_base_page.html
+++ b/toolkit/templates/layouts/_base_page.html
@@ -1,6 +1,6 @@
 {% extends "govuk/govuk_template.html" %}
 
-{% block head %} 
+{% block head %}
   {% block custom_meta %}{% include "toolkit/custom-dimensions.html" %}{% endblock %}
   {% include "toolkit/layouts/_stylesheets.html" %}
   {% include "toolkit/layouts/_site_verification.html" %}


### PR DESCRIPTION
 ## Summary
GOV.UK validation masthead patterns use `h2` rather than `h1` for their
validation mastheads which appear at the top of the page indicating some
errors during form submission. There are also accessibility and general
HTML-compliance issues with having more than one h1 on the page. Best
practice and guidance therefore indicates we should change our template
to using an h2 heading.

Finally, we include the `validation.html` in the base page layout for
the frontend toolkit, ensuring that all pages will correctly show
validation when errors are passed into the rendering template as
`errors`. This means that individual pages no longer need to include the
boilerplate code for including validation and it's available out of the
box.

 ## Ticket
https://trello.com/c/RSYEM3FL/448