### PR TITLE
Allow setting input type for textbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "29.0.0",
+  "version": "29.1.0",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/pages_builder/pages/forms/textbox.yml
+++ b/pages_builder/pages/forms/textbox.yml
@@ -132,3 +132,7 @@ examples:
     question: Textbox with message
     name: question-11
     message: You really need to know about this box
+  -
+    question: Textbox for password field
+    name: password-1
+    type: password

--- a/pages_builder/pages/forms/validation.yml
+++ b/pages_builder/pages/forms/validation.yml
@@ -6,17 +6,17 @@ examples:
   -
     title: Masthead
     errors:
-      -
+      example-textbox:
         input_name: example-textbox
         question: What was the name of your first pet?
-      -
-        input_name: example-textbox-2
+      example-textbox-2:
+        input_name:
         question: What street did you grow up on?
   -
     title: With a custom message and description
     lede: Something went wrong
     description: Please make it right
     errors:
-      -
+      example-textbox:
         input_name: example-textbox
         question: What was the name of your first pet?

--- a/toolkit/templates/forms/macros/forms.html
+++ b/toolkit/templates/forms/macros/forms.html
@@ -14,7 +14,9 @@
     unit=kwargs.get("unit", question_content.unit),
     unit_in_full=kwargs.get("unit_in_full", question_content.unit_in_full),
     unit_position=kwargs.get("unit_position", question_content.unit_position),
-    value=kwargs.get("value", data[question_content.id])
+    value=kwargs.get("value", data[question_content.id]),
+    type=kwargs.get("type", "text"),
+    autocomplete=kwargs.get("autocomplete")
   %}
     {% include "toolkit/forms/textbox.html" %}
   {% endwith %}
@@ -34,7 +36,9 @@
     question=kwargs.get("question", question_content.question),
     question_advice=kwargs.get("question_advice", question_content.question_advice),
     question_number=kwargs.question_number,
-    value=kwargs.get("value", data[question_content.id])
+    value=kwargs.get("value", data[question_content.id]),
+    type=kwargs.get("type", "text"),
+    autocomplete=kwargs.get("autocomplete")
   %}
     {% include "toolkit/forms/textbox.html" %}
   {% endwith %}

--- a/toolkit/templates/forms/textbox.html
+++ b/toolkit/templates/forms/textbox.html
@@ -4,6 +4,12 @@
 {% if question_advice %}
   {% set question_advice_id="input-" + name + "-question-advice" %}
 {% endif %}
+{% if not type %}
+  {% set type = "text" %}
+{% endif %}
+{% if not autocomplete and type == "password" %}
+  {% set autocomplete = "off" %}
+{% endif %}
 
 {% if error %}
   <div class="validation-wrapper">
@@ -84,11 +90,12 @@
         </label>
       {% endif %}
       <input
-        type="text"
+        type="{{ type }}"
         name="{{ name }}"
         id="input-{{ name }}"
         class="text-box{% if unit %}-with-unit-{{ unit_position }}{% endif %}{% if error %}-with-error{% endif %}{% if smaller %} text-box-smaller{% endif %}"
         value="{% if value !=  None %}{{ value }}{% endif %}"
+        {% if autocomplete %}autocomplete="{{ autocomplete }}"{% endif %}
         {% if aria_controls %}aria-controls="{{ aria_controls }}"{% endif %}
         {% if question_advice or hint %}aria-describedby="{{ [question_advice_id, answer_advice_id]|join(' ')|trim }}"{% endif %}
       />


### PR DESCRIPTION
 ## Summary
In order to change the user-frontend over to using frontend-toolkit
textbox macros rather than manually constructing the HTML, we need to be
able to set the type of the textbox to passwor so that we can obscure
text entry in the field. This adds a kwarg to textboxes for `type` that
defaults to `text`, but can be overridden as needed.

We also need to be able to toggle whether or not the input should allow
browser to autocomplete text in the box. By default, we will disable
autocomplete for password inputs.

 ## Ticket
https://trello.com/c/UtFxXymO/455