### PR TITLE
Iterate opt in flow for user research participants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Records breaking changes from major version bumps
 
+## 30.0.0
+
+PR: [441](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/441)
+
+### What changed
+User research consent banner will now show on every page that uses the new shared layouts (toolkit/templates/layouts/_base_page.html).
+This will also require each app to include the following files:
+- toolkit/javascripts/user-research-consent-banner.js
+- toolkit/scss/_user-research-consent-banner.scss
+
 ## 29.0.0
 
 PR: [439](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/439)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "29.1.0",
+  "version": "29.2.0",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "29.2.0",
+  "version": "30.0.0",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/toolkit/javascripts/user-research-consent-banner.js
+++ b/toolkit/javascripts/user-research-consent-banner.js
@@ -4,6 +4,10 @@
   var UserResearchBanner = function( _userResearchBanner ) {
     this.$userResearchBanner = _userResearchBanner;
     this.$userResearchBannerCloseBtn = this.$userResearchBanner.find('.user-research-banner-close-btn');
+
+    // Changing cookie name will require an update to the following files:
+    // digitalmarketplace-frontend-toolkit/toolkit/templates/user-research-consent-banner.html
+    // digitalmarketplace-user-frontend/app/main/views/notifications.py
     this.userResearchCookie = {
       name: 'seen_user_research_message',
       value: 'yes'

--- a/toolkit/javascripts/user-research-consent-banner.js
+++ b/toolkit/javascripts/user-research-consent-banner.js
@@ -43,7 +43,7 @@
   };
 
   UserResearchBanner.prototype.setCookie = function () {
-    return GOVUK.setCookie(this.userResearchCookie.name, this.userResearchCookie.value);
+    return GOVUK.setCookie(this.userResearchCookie.name, this.userResearchCookie.value, {days: 90});
   };
 
   $ = global.jQuery

--- a/toolkit/templates/layouts/_base_page.html
+++ b/toolkit/templates/layouts/_base_page.html
@@ -20,6 +20,12 @@
   {% include "toolkit/proposition-header.html" %}
 {% endblock %}
 
+{% block after_header %}
+  {% if not current_user.user_research_opted_in and not 'seen_user_research_message' in request.cookies %}
+    {% include "toolkit/user-research-consent-banner.html" %}
+  {% endif %}
+{% endblock %}
+
 {% block content %}
     {% block top_header %}
     {% endblock %}

--- a/toolkit/templates/layouts/_base_page.html
+++ b/toolkit/templates/layouts/_base_page.html
@@ -21,6 +21,10 @@
 {% endblock %}
 
 {% block after_header %}
+  {# Changing cookie name will require an update to the following files: #}
+  {# digitalmarketplace-frontend-toolkit/toolkit/javascripts/user-research-consent-banner.js #}
+  {# digitalmarketplace-user-frontend/app/main/views/notifications.py #}
+
   {% if not current_user.user_research_opted_in and not 'seen_user_research_message' in request.cookies %}
     {% include "toolkit/user-research-consent-banner.html" %}
   {% endif %}


### PR DESCRIPTION
**As a buyer I want to easily opt-in to user research so that I can help improve the buyer experience for G-Cloud**

The current opt-in journey has been unsuccessful, only 6 buyers have signed up. A higher number of suppliers, however, we suspect that this is due to G10 submission going on at the same time.

Buyer and suppliers cannot opt-in until they log in. Buyers and suppliers that don't log in don't have an opportunity to opt-in for user research.

***

**Changes**

Cookie banner to appear on all pages for logged in and logged out users until they click close or opt in. If clicked close, it reappears after 90 days.

***

**Notes**

Users will have to log in before they can opt-in.
We should use the existing opt-in journey as much as possible. This is non-mission work.

Ticket: https://trello.com/c/48pZNhaG/120-iterate-opt-in-flow-for-user-research-participants