### PR TITLE
Add `banner` option to temporary messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "31.0.2",
+  "version": "31.1.0",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/pages_builder/pages/temporary-message.yml
+++ b/pages_builder/pages/temporary-message.yml
@@ -18,6 +18,13 @@ examples:
     heading: Example without any body copy that is quite long and may wrap onto multiple lines
     grid: column-two-thirds
   -
+    heading: A full width banner with a top margin
+    messages:
+      - Temporary messages don't normally have a top margin.
+      - You can add one like this.
+      - It's useful for full width banner messages - it makes them play nicely with flash messages.
+    banner: True
+  -
     heading: G‑Cloud  is open for applications
     main: True
     messages:

--- a/toolkit/scss/_temporary-message.scss
+++ b/toolkit/scss/_temporary-message.scss
@@ -40,6 +40,11 @@
   padding-bottom: 5px;
 }
 
+.temporary-message-banner {
+  @extend %temporary-message-section;
+  margin-top: 15px;
+}
+
 .temporary-message-heading {
   @include bold-24;
   margin: 0 0 10px 0;

--- a/toolkit/templates/temporary-message.html
+++ b/toolkit/templates/temporary-message.html
@@ -1,4 +1,4 @@
-<div class="temporary-message{% if not messages %}-without-messages{% endif %}{% if main %}-main{% endif %}">
+<div class="temporary-message{% if not messages %}-without-messages{% endif %}{% if main %}-main{% endif %}{% if banner %}-banner{% endif %}">
   <{% if header_level %}{{ header_level }}{% else %}h3{% endif %} class="temporary-message-heading{% if main %}-main{% endif %}">
     {{ heading }}
   </{% if header_level %}{{ header_level }}{% else %}h3{% endif %}>


### PR DESCRIPTION
For [this ticket on Trello.](https://trello.com/c/LjbF4cLc)

Temporary messages had no margin at the top. This makes sense if in a
one-third column, or if there's nothing above it.

When used as a full width banner message however, if there is something
above it - such as a flash message - then there is no spacing between
them and it looks weird.

Flash messages use 15px of margin-top, so I've used the same value here.

### Before. Urgh.
![localhost_buyers_direct-award_g-cloud_projects_795908519637080 ipad pro](https://user-images.githubusercontent.com/13836290/41412855-403fdf90-6fd9-11e8-8f74-b4988f392984.png)

### After. Better.
![localhost_buyers_direct-award_g-cloud_projects_457356462217937 ipad pro](https://user-images.githubusercontent.com/13836290/41412862-45a86aba-6fd9-11e8-818b-8f10708c6872.png)
