### PR TITLE
Add `list-bullet-small`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "31.1.0",
+  "version": "31.2.0",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/pages_builder/pages/shared_scss/lists.yml
+++ b/pages_builder/pages/shared_scss/lists.yml
@@ -33,6 +33,35 @@ examples:
       </li>
     </ul>
   - |
+    <h2><code>.list-bullet-small</code></h2>
+    <br />
+    <ul class="list-bullet-small">
+      <li>
+        1 crisp celery stalk
+      </li>
+      <li>
+        lime wedge
+      </li>
+      <li>
+        ground pepper
+      </li>
+      <li>
+        celery salt
+      </li>
+      <li>
+        4 dashes worcestershire sauce
+      </li>
+      <li>
+        2 dashes tabasco sauce
+      </li>
+      <li>
+        1–1½ oz. vodka
+      </li>
+      <li>
+        6 oz. clamato juice
+      </li>
+    </ul>
+  - |
     <h2><code>.list-number</code></h2>
     <br />
     <ol class="list-number">

--- a/toolkit/scss/shared_scss/_lists.scss
+++ b/toolkit/scss/shared_scss/_lists.scss
@@ -21,6 +21,11 @@
   @include list-bullet;
 }
 
+.list-bullet-small {
+  @include core-16;
+  @include list-bullet;
+}
+
 .list-number {
   list-style-type: decimal;
   padding-left: 20px;


### PR DESCRIPTION
For [this trello ticket.](https://trello.com/c/LjbF4cLc)

Our temporary messages use `core-16`. Lists are only `core-19`. If we want
to use a list in a temporary message we need a smaller version.

### Before
<img width="1007" alt="screen shot 2018-06-14 at 16 30 46" src="https://user-images.githubusercontent.com/13836290/41422499-ee59f0cc-6ff0-11e8-8766-bce375bd8513.png">

### After
<img width="1004" alt="screen shot 2018-06-14 at 16 31 18" src="https://user-images.githubusercontent.com/13836290/41422508-f3569d50-6ff0-11e8-8ac1-dbe82a645cd9.png">
