### PR TITLE
Split validation masthead style into two bits.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "31.4.0",
+  "version": "31.5.0",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/toolkit/scss/forms/_validation.scss
+++ b/toolkit/scss/forms/_validation.scss
@@ -27,11 +27,13 @@
     margin-bottom: 5px;
   }
 
-  .validation-masthead-link,
-  .validation-masthead-link:link,
-  .validation-masthead-link:visited {
+  .validation-masthead-link {
     display: block;
     @include core-19;
+  }
+
+  :link,
+  :visited {
     font-weight: bold;
     color: $red;
   }


### PR DESCRIPTION
Normally, we have an <a> element that's treated as a block level el, but in some cases we want a custom message containing a link. When we do that, the link should be styled the same, i.e. red and bold.

https://trello.com/c/Z1a3weIe/131-replace-end-search-with-before-you-export-your-results