### PR TITLE
Add additional top margin to validation masthead

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "31.5.0",
+  "version": "31.6.0",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/toolkit/scss/forms/_validation.scss
+++ b/toolkit/scss/forms/_validation.scss
@@ -10,7 +10,7 @@
 
   border: 5px solid $red;
   padding: 15px 15px 20px 15px;
-  margin-bottom: 30px;
+  margin: 10px 0 30px 0;
 
   &:focus {
     outline: 3px solid $yellow;


### PR DESCRIPTION
The masthead should now have a gap between it and the banner.

# Before:

<img width="1005" alt="before" src="https://user-images.githubusercontent.com/3466862/42039866-44afcb90-7ae6-11e8-817b-b79ccbdee452.png">

# After:

<img width="986" alt="after" src="https://user-images.githubusercontent.com/3466862/42039873-4c27517c-7ae6-11e8-9796-dc1389be6717.png">

# After with breadcrumb:

<img width="983" alt="with breadcrumb" src="https://user-images.githubusercontent.com/3466862/42042201-8ad6065c-7aeb-11e8-8f57-be934844cbae.png">


https://trello.com/c/haJUQGB9/340-layout-issue-on-login-screen