### PR TITLE
Add an optional "finally, ..." clause to selection buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "31.5.0",
+  "version": "31.6.0",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/pages_builder/pages/forms/selection-buttons.yml
+++ b/pages_builder/pages/forms/selection-buttons.yml
@@ -301,3 +301,18 @@ examples:
       -
         label: "No"
         value: Not VAT registered
+  -
+    type: radio
+    name: finally-or-10
+    question: Radio box with "or" before the final option
+    finally: or
+    options:
+      -
+        label: Yes
+        value: yes
+      -
+        label: No
+        value: no
+      -
+        label: Maybe
+        value: maybe

--- a/toolkit/templates/forms/selection-buttons.html
+++ b/toolkit/templates/forms/selection-buttons.html
@@ -72,6 +72,9 @@
           %}
             {% include 'toolkit/forms/_selection-button.html' %}
           {% endwith %}
+          {% if finally and loop.revindex0 == 1 %}
+            <p class="form-block">{{ finally }}</p>
+          {% endif %}
         {% endfor %}
         {% if hint and hint_underneath %}
           <div class="hint-underneath" id="{{ answer_advice_id }}">


### PR DESCRIPTION
In a number of our forms (c.f. in buyer frontend choose-lot.html, save-search.html) we have the pattern where the final radio button is prefaced by a line reading "or", to signpost to the reader that it is an option unlike the others.

Currently the forms that do this do so by hand coding the form, rather than using the form template, or by mushing together several form templates.

By adding this feature to the form template, we can greatly simplify the places where this pattern is used.

---

## Examples

### On desktop
![Radio box with "or" before the final option](https://user-images.githubusercontent.com/503614/42938972-168029ce-8b4c-11e8-919c-39cc63ac4d86.png)

### On mobile
![Radio box with "or" before the final option in a mobile viewport](https://user-images.githubusercontent.com/503614/42939142-9754a62e-8b4c-11e8-8836-7270b25f890e.png)

### With an error
![Radio box with "or" before the final option and an error in a mobile viewport](https://user-images.githubusercontent.com/503614/42939235-e2762de4-8b4c-11e8-8af0-3f14ed4dc06c.png)
