### PR TITLE
Add an id to hidden fields so that the labels match correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "31.6.1",
+  "version": "31.6.2",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/toolkit/templates/forms/_selection-button.html
+++ b/toolkit/templates/forms/_selection-button.html
@@ -34,8 +34,9 @@
   {% set reveal_value = option.reveal['value'] %}
   {% set reveal_error = option.reveal['error'] %}
   {% set reveal_hint = option.reveal['hint'] %}
+  {% set reveal_id = "{}-{}".format(id, option.reveal['id']) if option.reveal['id'] else "{}-{}".format(id, reveal_name) %}
   <div class="panel {% if reveal_error %} form-group-error{% endif %} panel-border-narrow js-hidden" id="{{ reveal_name }}-target">
-    <label class="form-label" for="{{ reveal_name }}">
+    <label class="form-label" for="{{ reveal_id }}">
         {{ reveal_question }}
         {% if reveal_hint %}
           <span class="hint">{{ reveal_hint }}</span>
@@ -45,7 +46,7 @@
         {% endif %}
     </label>
     <div id="{{ reveal_name }}">
-      <input class="form-control{% if reveal_error %} form-control-error{% endif %}" name="{{ reveal_name }}" type="text" value="{{ reveal_value }}">
+      <input class="form-control{% if reveal_error %} form-control-error{% endif %}" id="{{ reveal_id }}" name="{{ reveal_name }}" type="text" value="{{ reveal_value }}">
     </div>
   </div>
 {% endif %}


### PR DESCRIPTION
For fields which are hidden behind a selection button, the label was 
associated with the div tag rather than the input tag.

This causes an issue with functional tests and also could cause an issue 
with accessability, so this commit changes the template so that the 
input field has an additional unique id that is used by it and the 
label.

I discovered this whilst working on [this ticket](https://trello.com/c/wlfBF5J0/51-buyer-fe-save-searchhtml-page-uses-blend-of-wtforms-raw-html-fe-toolkit-templates).