### PR TITLE
Add shared error templates to toolkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "31.6.2",
+  "version": "31.7.0",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/toolkit/templates/errors/400.html
+++ b/toolkit/templates/errors/400.html
@@ -1,0 +1,20 @@
+{% extends "toolkit/layouts/_base_page.html" %}
+
+{% block page_title %}Bad request - Digital Marketplace{% endblock %}
+
+{% block main_content %}
+
+<div class="error-page">
+    <header class="page-heading-smaller">
+      <h1>Sorry, there was a problem with your request</h1>
+    </header>
+    <p>
+      {% if error_message %}
+        {{ error_message }}
+      {% else %}
+        Please do not attempt the same request again.
+      {% endif %}
+    </p>
+</div>
+
+{% endblock %}

--- a/toolkit/templates/errors/404.html
+++ b/toolkit/templates/errors/404.html
@@ -1,0 +1,20 @@
+{% extends "toolkit/layouts/_base_page.html" %}
+
+{% block page_title %}Page could not be found - Digital Marketplace{% endblock %}
+
+{% block main_content %}
+
+<div class="error-page">
+  <header class="page-heading-smaller">
+    <h1>Page could not be found</h1>
+  </header>
+
+  <p>
+      Check you’ve entered the correct web address or start again on the Digital Marketplace homepage.
+  </p>
+  <p>
+      If you can’t find what you’re looking for, contact us at <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+  </p>
+</div>
+
+{% endblock %}

--- a/toolkit/templates/errors/410.html
+++ b/toolkit/templates/errors/410.html
@@ -1,0 +1,20 @@
+{% extends "toolkit/layouts/_base_page.html" %}
+
+{% block page_title %}Service no longer available - Digital Marketplace{% endblock %}
+
+{% block main_content %}
+
+<div class="error-page">
+    <header class="page-heading-smaller">
+        <h1>Page no longer available</h1>
+    </header>
+    <p>
+        The page you requested is no longer available on the Digital Marketplace.
+    </p>
+    <p>
+        If you can't find what you're looking for, email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20page%20gone" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+    </p>
+
+</div>
+
+{% endblock %}

--- a/toolkit/templates/errors/500.html
+++ b/toolkit/templates/errors/500.html
@@ -1,0 +1,20 @@
+{% extends "toolkit/layouts/_base_page.html" %}
+
+{% block page_title %}Sorry, we’re experiencing technical difficulties - Digital Marketplace{% endblock %}
+
+{% block main_content %}
+
+<div class="error-page">
+  <header class="page-heading-smaller">
+    <h1>Sorry, we’re experiencing technical difficulties</h1>
+  </header>
+  <p>
+    {% if error_message %}
+      {{ error_message }}
+    {% else %}
+      Try again later.
+    {% endif %}
+  </p>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
Trello: https://trello.com/c/kqjkCP72/101-move-csrf-session-expired-message-to-utils

When we pull in the new error handlers from utils, some error statuses are mapped to templates. This is an issue because:
- Not all the FE apps have error templates for each status code (most don't have a 410, for example)
- The templates vary in content and style between the FE apps
- Not all the templates accept a custom error message in the context

The content has been copied from existing FE apps (we can always tweak it later).

I tried adding some examples to the pages_builder documentation, but it struggles rendering a whole page (with extended blocks etc) rather than a small HTML snippet - the amount of effort to get that working outweighs its usefulness in my opinion.

We can add the 410 handler to utils once the apps have the template available.
