### PR TITLE
Support Flask-Login 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "31.7.0",
+  "version": "31.8.0",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/pages_builder/pages/proposition-header.yml
+++ b/pages_builder/pages/proposition-header.yml
@@ -27,7 +27,7 @@ examples:
             <a href="#" title="" id="logo" class="content"></a>
           </div>
         </div>
-        {% with logged_in=True, role='buyer' %}
+        {% with current_user=None %}
           {% include "proposition-header.html" %}
         {% endwith %}
       </div>
@@ -43,7 +43,7 @@ examples:
             <a href="#" title="" id="logo" class="content"></a>
           </div>
         </div>
-        {% with logged_in=True, role='supplier' %}
+        {% with current_user=None, logged_in=True, role='buyer' %}
           {% include "proposition-header.html" %}
         {% endwith %}
       </div>
@@ -59,9 +59,41 @@ examples:
             <a href="#" title="" id="logo" class="content"></a>
           </div>
         </div>
-        {% with logged_in=True, role='admin', items = [
+        {% with current_user=None, logged_in=True, role='supplier' %}
+          {% include "proposition-header.html" %}
+        {% endwith %}
+      </div>
+    </header>
+
+  - |
+    {% macro url_for(mocked_link_for_documentation_only) %}#{% endmacro %}
+    {% set csrf_token_value = 'token_set_for_documentation_only' %}
+    <header role="banner" id="global-header" class="">
+      <div class="header-wrapper">
+        <div class="header-global">
+          <div class="header-logo">
+            <a href="#" title="" id="logo" class="content"></a>
+          </div>
+        </div>
+        {% with current_user=None, logged_in=True, role='admin', items = [
           {"label": "Service status changes", "link": "#status-changes"}
         ] %}
+          {% include "proposition-header.html" %}
+        {% endwith %}
+      </div>
+    </header>
+
+  - |
+    {% macro url_for(mocked_link_for_documentation_only) %}#{% endmacro %}
+    {% set csrf_token_value = 'token_set_for_documentation_only' %}
+    <header role="banner" id="global-header" class="">
+      <div class="header-wrapper">
+        <div class="header-global">
+          <div class="header-logo">
+            <a href="#" title="" id="logo" class="content"></a>
+          </div>
+        </div>
+        {% with current_user={'is_authenticated': 'mocked_value'}, role='buyer' %}
           {% include "proposition-header.html" %}
         {% endwith %}
       </div>

--- a/toolkit/templates/proposition-header.html
+++ b/toolkit/templates/proposition-header.html
@@ -9,8 +9,13 @@
         <li>
           <a href="{{ url_for('external.help') }}">Help</a>
         </li>
-        {% set current_user_is_authenticated = current_user.is_authenticated() if current_user.is_authenticated is callable else current_user.is_authenticated %}
-        {% if (current_user_is_authenticated if logged_in is not defined else logged_in) %}
+        {% set user_logged_in = logged_in|default(false, true) %}
+
+        {% if current_user %}
+          {% set user_logged_in = current_user.is_authenticated() if current_user.is_authenticated is callable else current_user.is_authenticated %}
+        {% endif %}
+
+        {% if user_logged_in %}
           {% if (role or current_user.role) == 'buyer' %}
             <li>
               <a href="{{ url_for('external.buyer_dashboard') }}">View your account</a>

--- a/toolkit/templates/proposition-header.html
+++ b/toolkit/templates/proposition-header.html
@@ -9,27 +9,28 @@
         <li>
           <a href="{{ url_for('external.help') }}">Help</a>
         </li>
-          {% set current_user_is_authenticated = current_user.is_authenticated() if current_user.is_authenticated is callable else current_user.is_authenticated %}
-        {% if (current_user_is_authenticated if logged_in is not defined else logged_in) %} {% if (role or current_user.role) == 'buyer' %}
-        <li>
-          <a href="{{ url_for('external.buyer_dashboard') }}">View your account</a>
-        </li>
-        {% elif (role or current_user.role) == 'supplier' %}
-        <li>
-          <a href="{{ url_for('external.supplier_dashboard') }}">View your account</a>
-        </li>
-        {% endif %} 
-        {% for item in items %}
-        <li>
-          <a href="{{ item.link }}">{{ item.label }}</a>
-        </li>
-        {% endfor %}
-        <li>
-          <form method="post" action="{{ url_for('external.user_logout') }}">
-            <input type="submit" class="logout-button" value="Log out" />
-            <input type="hidden" name="csrf_token" value="{{ csrf_token_value or csrf_token() }}" />
-          </form>
-        </li>
+        {% set current_user_is_authenticated = current_user.is_authenticated() if current_user.is_authenticated is callable else current_user.is_authenticated %}
+        {% if (current_user_is_authenticated if logged_in is not defined else logged_in) %}
+          {% if (role or current_user.role) == 'buyer' %}
+            <li>
+              <a href="{{ url_for('external.buyer_dashboard') }}">View your account</a>
+            </li>
+          {% elif (role or current_user.role) == 'supplier' %}
+            <li>
+              <a href="{{ url_for('external.supplier_dashboard') }}">View your account</a>
+            </li>
+          {% endif %}
+          {% for item in items %}
+            <li>
+              <a href="{{ item.link }}">{{ item.label }}</a>
+            </li>
+          {% endfor %}
+          <li>
+            <form method="post" action="{{ url_for('external.user_logout') }}">
+              <input type="submit" class="logout-button" value="Log out" />
+              <input type="hidden" name="csrf_token" value="{{ csrf_token_value or csrf_token() }}" />
+            </form>
+          </li>
         {% else %}
         <li>
           <a href="{{ url_for('external.render_login') }}">Log in</a>

--- a/toolkit/templates/proposition-header.html
+++ b/toolkit/templates/proposition-header.html
@@ -9,7 +9,8 @@
         <li>
           <a href="{{ url_for('external.help') }}">Help</a>
         </li>
-        {% if (current_user.is_authenticated() if logged_in is not defined else logged_in) %} {% if (role or current_user.role) == 'buyer' %}
+          {% set current_user_is_authenticated = current_user.is_authenticated() if current_user.is_authenticated is callable else current_user.is_authenticated %}
+        {% if (current_user_is_authenticated if logged_in is not defined else logged_in) %} {% if (role or current_user.role) == 'buyer' %}
         <li>
           <a href="{{ url_for('external.buyer_dashboard') }}">View your account</a>
         </li>


### PR DESCRIPTION
Trello: https://trello.com/c/euSnpBnN/65-update-flask-login

`current_user.is_authenticated()` is now an attribute, not a method (see Flask-Login Changelog: https://github.com/maxcountryman/flask-login/blob/master/CHANGES). This means the FE toolkit's `proposition-header.html` template breaks when it tries to call it.

Happily Jinja can check whether the object is a callable and evaluate it accordingly: http://jinja.pocoo.org/docs/2.10/templates/#callable

Also did some whitespace tidying so the multiple `if..else`s are a bit clearer.