### PR TITLE
Remove requirement on virtualenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
-sudo: false
 node_js:
  - "0.12"
+before_install:
+  sudo apt-get install python3-venv
 install:
  - npm install
 script:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$VIRTUAL_ENV)
 
 virtualenv:
-	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && virtualenv -p python3 venv || true
+	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && python3 -m venv venv || true
 
 requirements: virtualenv
 	${VIRTUALENV_ROOT}/bin/pip install -r pages_builder/requirements.txt

--- a/README.md
+++ b/README.md
@@ -23,17 +23,11 @@ The documentation is generated from the contents of this repository.
 
 ### Setup
 
-Install [Virtualenv](https://virtualenv.pypa.io/en/latest/)
-
-```
-sudo easy_install virtualenv
-```
-
 Create a virtual environment in the checked-out repository folder
 
 ```
 cd digitalmarketplace-frontend-toolkit
-virtualenv ./venv
+python3 -m venv ./venv
 ```
 
 ### Activate the virtual environment


### PR DESCRIPTION
Python36 includes the venv module which means we no longer need virtualenv to be installed on the development system