### PR TITLE
Shared footer SCSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "31.8.0",
+  "version": "31.9.0",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/toolkit/scss/_footer.scss
+++ b/toolkit/scss/_footer.scss
@@ -1,0 +1,108 @@
+@import "_typography.scss";
+@import "_colours.scss";
+@import "_grid_layout.scss";
+@import "_measurements.scss";
+
+#footer {
+
+  .footer-categories, .footer-meta {
+    @extend %grid-row;
+  }
+
+  .footer-categories {
+
+    .footer-about,
+    .footer-buyers,
+    .footer-suppliers {
+      @include grid-column( 1/3 );
+      @include media(tablet) {
+        padding-bottom: $gutter * 2;
+      }
+    }
+
+    h2 {
+
+      @include bold-19;
+      padding: 10px 0 0;
+      margin: 0;
+      border-bottom: none;
+
+      @include media(tablet) {
+
+        padding: 0 0 20px;
+        border-bottom: 1px solid #a1acb2;
+
+      }
+
+    }
+
+    ul {
+      @include core-16;
+      list-style: none;
+      padding: 0;
+      margin: 0;
+
+      @include media(tablet) {
+
+        margin-top: $gutter-half;
+
+      }
+
+      li {
+        display: block;
+        margin-bottom: 5px;
+
+        padding: 10px 0 0;
+        margin: 0 $gutter-half 5px 0;
+
+        @include media(tablet){
+          padding: $gutter-half 0 0;
+          margin: 0 $gutter-half 0 0;
+        }
+      }
+    }
+
+    hr {
+      clear: both;
+      margin: $gutter 0;
+      border: 1px solid $border-colour;
+      border-width: 1px 0 0 0;
+
+      @include media(tablet) {
+        margin-top: 0;
+      }
+    }
+
+  }
+
+  .footer-meta {
+    padding-left: $gutter-half;
+    padding-right: $gutter-half;
+    @include media(tablet) {
+      padding-left: 0;
+      padding-right: 0
+    }
+    /* Temporary fix:
+       chrome is breaking this layout when font-size-adjust is set */
+    font-size-adjust: none;
+
+    .terms-and-conditions {
+      display: block;
+      @include core-16;
+      margin: 0 0 20px 0;
+    }
+
+  }
+
+  .footer-meta .footer-meta-inner {
+
+    .open-government-licence p {
+
+      padding-bottom: 0;
+
+      a {
+        font-size: 16px;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Trello: https://trello.com/c/Wnrvezi2/174-admin-404-error-template-footer-looks-weird

All our frontend apps (except the Admin FE) use the same footer layout and content, from the shared `_base_page.html` and `_footer_categories.html` toolkit templates. 

The Admin FE doesn't show `_footer_categories.html` for its normal pages, but its (shared) error pages do show them. However the Admin FE doesn't have any footer category CSS, so the error page footers look weird (hence this ticket).

Rather than copy over the duplicated `_footer.scss` to the Admin, I thought it would be nice to centralise it in the toolkit.

