### PR TITLE
Try out Gulp 4 in FE toolkit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
 install:
  - npm install
 script:
- - npm test
+ - make test
  - make generate_pages
 notifications:
  email: false

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ npm_copy:
 npm_clean:
 	npm run clean
 
+test: npm_install
+	npm test
+
 generate_pages: requirements npm_install npm_clean npm_copy
 	${VIRTUALENV_ROOT}/bin/python pages_builder/generate_pages.py
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,7 +55,9 @@ gulp.task(
 );
 
 gulp.task('copy',
-  ['copy:govuk_frontend_toolkit', 'copy:govuk-elements-sass']
+  gulp.parallel(
+    'copy:govuk_frontend_toolkit', 'copy:govuk-elements-sass'
+  )
 );
 
 // Test

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -79,7 +79,7 @@ gulp.task('test', function () {
 
   return gulp.src(manifest.test)
     .pipe(jasmine({
-      'jasmine': '2.0',
+      'jasmine': '3.1',
       'integration': true,
       'abortOnFail': true,
       'vendor': manifest.support

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "del": "^2.2.2",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",
-    "gulp": "3.8.11",
+    "gulp": "4.0.0",
     "gulp-jasmine-phantom": "3.0.0",
     "jasmine-core": "3.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "govuk_frontend_toolkit": "5.0.3",
     "gulp": "3.8.11",
     "gulp-jasmine-phantom": "3.0.0",
-    "jasmine-core": "2.6.4"
+    "jasmine-core": "3.1.0"
   },
   "scripts": {
     "clean": "./node_modules/gulp/bin/gulp.js clean",


### PR DESCRIPTION
Trello: https://trello.com/c/yblj0qeA/305-update-gulp-to-version-4

Dipping a toe in the water to see how potentially awful this might be. Outcome: not that bad!

- Added a `make test` command to shield us from the dreaded npm as much as posisble
- Upgrade `jasmine-core` to fix a low risk vulnerability https://app.snyk.io/vuln/npm:jasmine-core:20180216
- Upgrade gulp to v4: only a small change to a parallelised task was required.