### PR TITLE
Upgrade FE toolkit dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
- - "0.12"
+ - "8.12.0"
 install:
  - npm install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 install:
  - npm install
 script:
- - npm test
+ - make test
  - make generate_pages
 notifications:
  email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Records breaking changes from major version bumps
 
+## 32.0.0
+
+PR: [466](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/466)
+
+Bumps the engine to `node == 8.12.0` and gulp to `4.0.0`.
+Recommend thoroughly testing before pulling into a frontend app.
+
 ## 31.0.0
 
 PR: [442](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/442)

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ npm_copy:
 npm_clean:
 	npm run clean
 
+test: npm_install
+	npm test
+
 generate_pages: requirements npm_install npm_clean npm_copy
 	${VIRTUALENV_ROOT}/bin/python pages_builder/generate_pages.py
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,7 +55,9 @@ gulp.task(
 );
 
 gulp.task('copy',
-  ['copy:govuk_frontend_toolkit', 'copy:govuk-elements-sass']
+  gulp.parallel(
+    'copy:govuk_frontend_toolkit', 'copy:govuk-elements-sass'
+  )
 );
 
 // Test

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -79,7 +79,7 @@ gulp.task('test', function () {
 
   return gulp.src(manifest.test)
     .pipe(jasmine({
-      'jasmine': '2.0',
+      'jasmine': '3.1',
       'integration': true,
       'abortOnFail': true,
       'vendor': manifest.support

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,
-  "engine": "node == 6.10.3",
+  "engine": "node == 8.12.0",
   "dependencies": {
     "del": "^4.1.0",
     "govuk-elements-sass": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "del": "^2.2.2",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",
-    "gulp": "3.8.11",
+    "gulp": "4.0.0",
     "gulp-jasmine-phantom": "3.0.0",
     "jasmine-core": "3.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "govuk_frontend_toolkit": "5.0.3",
     "gulp": "3.8.11",
     "gulp-jasmine-phantom": "3.0.0",
-    "jasmine-core": "2.6.4"
+    "jasmine-core": "3.1.0"
   },
   "scripts": {
     "clean": "./node_modules/gulp/bin/gulp.js clean",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "31.11.0",
+  "version": "32.0.0",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
   "private": true,
   "engine": "node == 6.10.3",
   "dependencies": {
-    "del": "^2.2.2",
+    "del": "^4.1.0",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",
     "gulp": "4.0.0",
     "gulp-jasmine-phantom": "3.0.0",
-    "jasmine-core": "3.1.0"
+    "jasmine-core": "3.4.0"
   },
   "scripts": {
     "clean": "./node_modules/gulp/bin/gulp.js clean",

--- a/pages_builder/requirements.txt
+++ b/pages_builder/requirements.txt
@@ -3,7 +3,7 @@ libsass==0.11.1
 pystache==0.5.4
 requests==2.20.0
 six==1.8.0
-Jinja2==2.7.3
+Jinja2==2.10.1
 Pygments==2.0.2
 watchdog==0.8.3
 termcolor==1.1.0


### PR DESCRIPTION
Trello: https://trello.com/c/nLGfr8un/445-frontend-toolkit-is-pinned-to-node-6

Way back in the mists of time, I tried upgrading gulp to v4 here as well (see https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/461), eventually closing the PR due to a vulnerability. This vulnerability is now fixed! So let's try again with:

- bump `node` to v8
- bump `gulp` to v4 (and update the `gulpfile` to work with v4)
- bump `jasmine-core` and `del` to most recent versions
- include my nice `make test` command and put it in travis.yml
