### PR TITLE
497-spike-4h-back-button-does-not-work-as-expected-on-search-page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "32.0.0",
+  "version": "32.0.1",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/toolkit/javascripts/live-search.js
+++ b/toolkit/javascripts/live-search.js
@@ -49,8 +49,10 @@ endpoint response (application/json):
     this.resultsCache = {};
 
     if(GOVUK.GDM.support.history()) {
+      this.originalState = this.$form.serializeArray();
       this.saveState();
       this.$form.on('change', 'input[type=checkbox], input[type=search], input[type=radio]', this.formChange.bind(this));
+      $(window).on('popstate', this.popState.bind(this));
 
       this.$form.find('input[type=submit]').click(
         function(e){
@@ -85,10 +87,13 @@ endpoint response (application/json):
   LiveSearch.prototype.popState = function popState(event){
     if(event.originalEvent.state){
       this.saveState(event.originalEvent.state);
-      this.updateResults();
-      this.restoreBooleans();
-      this.restoreSearchInputs();
+    } else {
+      this.saveState(this.originalState);
     }
+
+    this.restoreBooleans();
+    this.restoreSearchInputs();
+    this.updateResults();
   };
 
   LiveSearch.prototype.formChange = function formChange(e){


### PR DESCRIPTION
https://trello.com/c/kcElJmwF/479-spike-4h-back-button-does-not-work-as-expected-on-search-page

* Bind the popState method to the popstate event
  * As per https://github.com/openregister/finder-demo/blob/dc2ffc9a0497f2cd2d00996ae70b7297bade38f5/app/assets/javascripts/finder/live_search.js#L31
  * The popstate method was never being called, the popstate event is issued when the browser back button is pressed
    * https://stackoverflow.com/a/37115083/3967444
  * This fixed the back button functionality loading results except in the case of returning to the originally loaded page (or the _initial state_ in the chain)

* Store the original state of the form on load. This is where we want to get back to eventually in the case of the 'initial state'
* The problems with the intial state popstate event were caused by it not having an `originalEvent.state`
  * https://stackoverflow.com/a/7860987/3967444
  * > the state is only defined when the new state has data, so it is not available when clicking and then going back to the initial state

* When we detect a popstate event that doesn't have an `originalEvent.state` set the state to the `originalState` event we defined when the form was loaded

* There was also a bug in the popstate method (which had never been called).
  * `updateResults` relies on the 'current' state of the form. Ie it will update the form with the results required by the form in its current state
  * It needs to be called after we update the form attributes with `restoreBooleans` and `restoreSearchInputs`