### PR TITLE
479-spike-4h-back-button-does-not-work-as-expected-on-search-page-2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "32.0.2",
+  "version": "32.0.3",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/toolkit/javascripts/live-search.js
+++ b/toolkit/javascripts/live-search.js
@@ -166,7 +166,8 @@ endpoint response (application/json):
   }
 
   LiveSearch.prototype.displayFilterResults = function displayFilterResults(response, state) {
-    if(state == $.param(this.state)) {
+    // The !(state === "") is required for browser versions which trigger the popstate event on first pageload
+    if(state == $.param(this.state) && !(state === "")) {
       for (var blockToReplace in response) {
         this.replaceBlock(response[blockToReplace]['selector'], response[blockToReplace]['html']);
       }


### PR DESCRIPTION
Mitigation for browser versions that call popstate on pageload as opposed to just browser back/ forward events