### PR TITLE
Remove "report a problem" form from the base page template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Records breaking changes from major version bumps
 
+## 33.0.0
+
+Remove the "report a problem" form from the base page template.
+
 ## 32.0.0
 
 PR: [466](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/466)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "32.0.3",
+  "version": "33.0.0",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/toolkit/templates/layouts/_base_page.html
+++ b/toolkit/templates/layouts/_base_page.html
@@ -41,7 +41,6 @@
       {% endblock %}
     </main>
   </div>
-{% include "toolkit/report-a-problem.html" %}
 {% endblock %}
 
 {% block footer_top %}


### PR DESCRIPTION
Ticket: https://trello.com/c/z63XpU1l/548-remove-is-there-anything-wrong-with-this-page-form

The feedback forms at the bottom of each page have been causing confusion for users who use this form when they should be contacting support.

For now the quick fix is to remove the link from the page template. The code has been left to allow it to be quickly added back.

I've put this as a breaking change as it's removing a feature; it won't break functional tests, but I believe that some if not all apps test the functionality in their unit tests.