### PR TITLE
Strip tags from validation message bookmark links

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "33.0.1",
+  "version": "33.0.2",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/toolkit/templates/forms/validation.html
+++ b/toolkit/templates/forms/validation.html
@@ -9,7 +9,7 @@
     </p>
   {% endif %}
   {% for error in errors.values() %}
-    <a href="#{{ error.input_name }}" class="validation-masthead-link">{{ error.question }}</a>
+    <a href="#{{ error.input_name }}" class="validation-masthead-link">{{ error.question|striptags }}</a>
   {% endfor %}
 </div>
 {% endif %}


### PR DESCRIPTION
https://trello.com/c/hJQFvCUe/569-dos4-service-question-error-banner-breaks-with-question-containing-link

Some of our form validation messages replay the question text as a bookmark link, to help the user jump to the affected area quickly. If the question text itself contains a link, the bookmark breaks.

Stripping the tags from the question text solves the issue. Other masthead/flash messages (that may contain links) should not be affected - this will only be used for form validation errors containing content loader questions.

Fixed error message:
![validation-masthead-links](https://user-images.githubusercontent.com/3492540/60176134-5afc6d00-980d-11e9-9168-4f24d17bebca.png)
