### PR TITLE
javascript: add xhr-semaphore.js for maintaining a GOVUK.xhr_semaphore value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "33.0.2",
+  "version": "33.1.0",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/spec/javascripts/manifest.js
+++ b/spec/javascripts/manifest.js
@@ -13,7 +13,8 @@ var manifest = {
     '../../../toolkit/javascripts/validation.js',
     '../../../toolkit/javascripts/word-counter.js',
     '../../../toolkit/javascripts/support.js',
-    '../../../toolkit/javascripts/live-search.js'
+    '../../../toolkit/javascripts/live-search.js',
+    '../../../toolkit/javascripts/xhr-semaphore.js'
   ],
   test : [
     '../unit/ListEntrySpec.js',

--- a/toolkit/javascripts/xhr-semaphore.js
+++ b/toolkit/javascripts/xhr-semaphore.js
@@ -1,0 +1,18 @@
+// a globally-kept ajax request semaphore allows code (notably test code) to know that an XMLHTTPRequest
+// is still in flight.
+
+;(function() {
+  "use strict";
+
+  this.GOVUK = this.GOVUK || {};
+  GOVUK = this.GOVUK;
+  GOVUK.xhr_semaphore = GOVUK.xhr_semaphore || 0;
+
+  $(document).ajaxSend(function() {
+    GOVUK.xhr_semaphore += 1;
+  });
+
+  $(document).ajaxComplete(function() {
+    GOVUK.xhr_semaphore -= 1;
+  });
+}).call(this);


### PR DESCRIPTION
https://trello.com/c/6htyRkFX

This value gets incremented as an ajax request is started and decremented when it ends (either successfully or not), so can be used by test code to back off when it knows there's still an ajax request in-flight, implemented using the jquery global ajax handlers.