### PR TITLE
Switch support email on error pages to CCS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "34.0.0",
+  "version": "34.1.0",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/toolkit/templates/errors/404.html
+++ b/toolkit/templates/errors/404.html
@@ -13,7 +13,7 @@
       Check you’ve entered the correct web address or start again on the Digital Marketplace homepage.
   </p>
   <p>
-      If you can’t find what you’re looking for, contact us at <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+      If you can’t find what you’re looking for, contact us at <a href="mailto:cloud_digital@crowncommercial.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to cloud_digital@crowncommercial.gov.uk">cloud_digital@crowncommercial.gov.uk</a>
   </p>
 </div>
 

--- a/toolkit/templates/errors/410.html
+++ b/toolkit/templates/errors/410.html
@@ -12,7 +12,7 @@
         The page you requested is no longer available on the Digital Marketplace.
     </p>
     <p>
-        If you can't find what you're looking for, email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20page%20gone" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+        If you can't find what you're looking for, email <a href="mailto:cloud_digital@crowncommercial.gov.uk?subject=Digital%20Marketplace%20page%20gone" title="Please send feedback to cloud_digital@crowncommercial.gov.uk">cloud_digital@crowncommercial.gov.uk</a>
     </p>
 
 </div>

--- a/toolkit/templates/phase-banner.html
+++ b/toolkit/templates/phase-banner.html
@@ -1,6 +1,6 @@
 {% set phase = "alpha" if alpha else "beta" %}
 <div class="phase-banner">
   <p>
-    <strong class="phase-tag">{{ phase|upper }}</strong> This is a{% if phase[0] in "aeiouy" %}n{% endif %} {% if phase == "beta" %}<a href="https://www.gov.uk/help/beta">{{ phase }} service</a>{% else %}{{ phase }} service{% endif %}  – please send your feedback to  <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+    <strong class="phase-tag">{{ phase|upper }}</strong> This is a{% if phase[0] in "aeiouy" %}n{% endif %} {% if phase == "beta" %}<a href="https://www.gov.uk/help/beta">{{ phase }} service</a>{% else %}{{ phase }} service{% endif %}  – please send your feedback to  <a href="mailto:cloud_digital@crowncommercial.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to cloud_digital@crowncommercial.gov.uk">cloud_digital@crowncommercial.gov.uk</a>
   </p>
 </div>


### PR DESCRIPTION
https://trello.com/c/ZTIHOFaJ/146-find-and-replace-old-support-address-to-new-address-your-account-has-been-locked-page-update-support-e-mail-address

From 8th July, support queries will be handled by the CCS team. Let's use their email instead of `enquiries@digitalmarketplace.service.gov.uk`.
