### PR TITLE
base template footer: fix "Applying to sell on the Digital Outcomes and Specialists framework" link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "34.2.0",
+  "version": "34.3.0",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/toolkit/templates/layouts/_footer_categories.html
+++ b/toolkit/templates/layouts/_footer_categories.html
@@ -40,7 +40,7 @@
         <a href="https://www.gov.uk/guidance/g-cloud-suppliers-guide">Applying to sell on the G-Cloud framework</a>
       </li>
       <li>
-        <a href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide#types-of-digital-services-you-can-sell">Applying to sell on the Digital Outcomes and Specialists framework</a>
+        <a href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide">Applying to sell on the Digital Outcomes and Specialists framework</a>
       </li>
       <li>
         <a href="https://www.gov.uk/guidance/how-to-sell-your-digital-outcomes-and-specialists-services">Responding to buyer requirements on the Digital Outcomes and Specialists framework</a>


### PR DESCRIPTION
https://trello.com/c/lxumtOjc/279

Needs a quick fix