### PR TITLE
Fix: strip PII from linked domain tracker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "35.0.0",
+  "version": "35.0.1",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/toolkit/javascripts/analytics/_googleAnalyticsUniversalTracker.js
+++ b/toolkit/javascripts/analytics/_googleAnalyticsUniversalTracker.js
@@ -150,6 +150,7 @@
     sendToGa(name + '.linker:autoLink', domains)
 
     sendToGa(name + '.set', 'anonymizeIp', true)
+    sendToGa(name + '.set', 'location', pii.stripPII(window.location.href))
     sendToGa(name + '.send', 'pageview')
   }
 


### PR DESCRIPTION
https://trello.com/c/XzgBSxIQ/1125-fwd-important-cross-domain-tracking-for-govuk-and-digital-market-place-service

Further testing showed that we'd missed an additional step where we need to strip PII from location property. Previously we were stripping it from the main `ga("send", "pageview")` call but not the linked beacon `ga("govuk_shared.send", "pageview")` call.