### PR TITLE
Change single field pricing question to also look for maximum price

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
-  "version": "36.1.0",
+  "version": "36.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "digitalmarketplace-frontend-toolkit",
   "description": "A toolkit for design patterns used across Digital Marketplace projects",
-  "version": "36.1.0",
+  "version": "36.1.1",
   "repository": "git@github.com:alphagov/digitalmarketplace-frontend-toolkit.git",
   "author": "enquiries@digitalmarketplace.service.gov.uk",
   "private": true,

--- a/toolkit/templates/forms/pricing.html
+++ b/toolkit/templates/forms/pricing.html
@@ -59,7 +59,7 @@
   <input
     type="text"
     class="text-box-with-unit-before"
-    name="{{ fields.price }}"
+    name="{{ fields.price if fields.price else fields.maximum_price }}"
     id="input-{{ name }}"
     value="{{ price or "" }}"
     {% if aria_controls %}aria-controls="{{ aria_controls }}"{% endif %}


### PR DESCRIPTION
Before DOS5 all pricing questions with a single field were on G-Cloud and the field was `price`. In DOS5 we switched to asking for only a specialist's maximum day rate, rather than both a maximum and minimum rate. This means we now have single field pricing questions with fields `price` and `maximum_price`.

The field name is used to populate the form input name, for questions with `maximum_price` this attribute was empty. This caused a bug in the admin-frontend where an admin user could not update a DOS5 specialists maximum day rate.

Update the name attribute on single field questions to look for `maximum_price` if `price` is not present. I initially felt a bit bad about hard-coding the second option, but logically it does make sense that a single field pricing question is either asking for a service's price (G-Cloud) or maximum price (DOS specialists).
I have checked the other questions in DOS and G-Cloud and verified that these are the only two fields that appear on their own.

https://trello.com/c/XGAEqKRu/2165-ccs-category-admins-cant-add-new-specialist-types-to-digital-specialists-services-on-dos5