### PR TITLE
reflect use of built in venv rather than virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,10 @@ The documentation is generated from the contents of this repository.
 
 ### Setup
 
-Install [Virtualenv](https://virtualenv.pypa.io/en/latest/)
-
-```
-sudo easy_install virtualenv
-```
-
 Create a virtual environment in the checked-out repository folder
 
 ```
-cd digitalmarketplace-frontend-toolkit
-virtualenv ./venv
+make virtualenv
 ```
 
 ### Activate the virtual environment


### PR DESCRIPTION
In #495 we switched from using `virtualenv` to python built-in `venv`. This updates the README to reflect that change.